### PR TITLE
Revm optim

### DIFF
--- a/src/algorithms/div/knuth.rs
+++ b/src/algorithms/div/knuth.rs
@@ -192,7 +192,7 @@ mod tests {
     use super::*;
     use crate::algorithms::{
         add::{cmp, sbb_n},
-        mul,
+        addmul,
     };
     use proptest::{
         collection, num, proptest,
@@ -324,7 +324,7 @@ mod tests {
         proptest!(|(quotient in quotient, (divisor, remainder) in dr)| {
             let mut numerator: Vec<u64> = vec![0; divisor.len() + quotient.len()];
             numerator[..remainder.len()].copy_from_slice(&remainder);
-            mul(quotient.as_slice(), divisor.as_slice(), &mut numerator);
+            addmul(&mut numerator, quotient.as_slice(), divisor.as_slice());
 
             div_nxm_normalized(numerator.as_mut_slice(), divisor.as_slice());
             let (r, q) = numerator.split_at(divisor.len());
@@ -500,7 +500,7 @@ mod tests {
         proptest!(|(quotient in quotient, (mut divisor, remainder) in dr)| {
             let mut numerator: Vec<u64> = vec![0; divisor.len() + quotient.len()];
             numerator[..remainder.len()].copy_from_slice(&remainder);
-            mul(quotient.as_slice(), divisor.as_slice(), &mut numerator);
+            addmul(&mut numerator, quotient.as_slice(), divisor.as_slice());
 
             div_nxm(numerator.as_mut_slice(), divisor.as_mut_slice());
             assert_eq!(&numerator[..quotient.len()], quotient);

--- a/src/algorithms/div/small.rs
+++ b/src/algorithms/div/small.rs
@@ -278,9 +278,8 @@ pub fn div_3x2_mg10(u21: u128, u0: u64, d: u128, v: u64) -> (u64, u128) {
 
 #[cfg(test)]
 mod tests {
-    use crate::algorithms::mul;
-
     use super::*;
+    use crate::algorithms::addmul;
     use proptest::{
         collection,
         num::{u128, u64},
@@ -350,7 +349,7 @@ mod tests {
             remainder %= divisor;
             let mut numerator = vec![0; quotient.len() + 1];
             numerator[0] = remainder;
-            mul(&quotient, &[divisor], &mut numerator);
+            addmul(&mut numerator, &quotient, &[divisor]);
 
             // Test
             let r = div_nx1_normalized(&mut numerator, divisor);
@@ -367,7 +366,7 @@ mod tests {
             // Construct problem
             let mut numerator = vec![0; quotient.len() + 1];
             numerator[0] = remainder;
-            mul(&quotient, &[divisor], &mut numerator);
+            addmul( &mut numerator, &quotient, &[divisor]);
 
             // Trim numerator
             while numerator.last() == Some(&0) {
@@ -391,7 +390,7 @@ mod tests {
             let mut numerator = vec![0; quotient.len() + 2];
             numerator[0] = remainder.low();
             numerator[1] = remainder.high();
-            mul(&quotient, &[divisor.low(), divisor.high()], &mut numerator);
+            addmul(&mut numerator, &quotient, &[divisor.low(), divisor.high()]);
 
             // Test
             let r = div_nx2_normalized(&mut numerator, divisor);
@@ -409,7 +408,7 @@ mod tests {
             let mut numerator = vec![0; quotient.len() + 2];
             numerator[0] = remainder.low();
             numerator[1] = remainder.high();
-            mul(&quotient, &[divisor.low(), divisor.high()], &mut numerator);
+            addmul(&mut numerator, &quotient, &[divisor.low(), divisor.high()]);
 
             // Trim numerator
             while numerator.last() == Some(&0) {

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -14,7 +14,7 @@ mod shift;
 pub use self::{
     div::div,
     gcd::{gcd, gcd_extended, inv_mod, LehmerMatrix},
-    mul::{mul, mul_inline},
+    mul::{addmul, submul_nx1},
     mul_redc::mul_redc,
     shift::{shift_left_small, shift_right_small},
 };

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -14,13 +14,14 @@ mod shift;
 pub use self::{
     div::div,
     gcd::{gcd, gcd_extended, inv_mod, LehmerMatrix},
-    mul::{addmul, submul_nx1},
+    mul::{addmul, addmul_nx1, submul_nx1},
     mul_redc::mul_redc,
     shift::{shift_left_small, shift_right_small},
 };
 
 trait DoubleWord<T>: Sized + Copy {
     fn join(high: T, low: T) -> Self;
+    fn add(a: T, b: T) -> Self;
     fn mul(a: T, b: T) -> Self;
     fn muladd(a: T, b: T, c: T) -> Self;
     fn muladd2(a: T, b: T, c: T, d: T) -> Self;
@@ -36,16 +37,27 @@ impl DoubleWord<u64> for u128 {
         (Self::from(high) << 64) | Self::from(low)
     }
 
+    /// Computes `a + b` as a 128-bit value.
+    #[inline(always)]
+    fn add(a: u64, b: u64) -> Self {
+        Self::from(a) + Self::from(b)
+    }
+
+    /// Computes `a * b` as a 128-bit value.
     #[inline(always)]
     fn mul(a: u64, b: u64) -> Self {
         Self::from(a) * Self::from(b)
     }
 
+    /// Computes `a * b + c` as a 128-bit value. Note that this can not
+    /// overflow.
     #[inline(always)]
     fn muladd(a: u64, b: u64, c: u64) -> Self {
         Self::from(a) * Self::from(b) + Self::from(c)
     }
 
+    /// Computes `a * b + c + d` as a 128-bit value. Note that this can not
+    /// overflow.
     #[inline(always)]
     fn muladd2(a: u64, b: u64, c: u64, d: u64) -> Self {
         Self::from(a) * Self::from(b) + Self::from(c) + Self::from(d)

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -14,7 +14,7 @@ mod shift;
 pub use self::{
     div::div,
     gcd::{gcd, gcd_extended, inv_mod, LehmerMatrix},
-    mul::{addmul, addmul_nx1, submul_nx1},
+    mul::{addmul, addmul_n, addmul_nx1, submul_nx1},
     mul_redc::mul_redc,
     shift::{shift_left_small, shift_right_small},
 };
@@ -87,7 +87,8 @@ pub mod bench {
     use criterion::Criterion;
 
     pub fn group(criterion: &mut Criterion) {
-        gcd::bench::group(criterion);
+        mul::bench::group(criterion);
         div::bench::group(criterion);
+        gcd::bench::group(criterion);
     }
 }

--- a/src/algorithms/mul_redc.rs
+++ b/src/algorithms/mul_redc.rs
@@ -1,4 +1,4 @@
-use super::mul;
+use super::addmul;
 use core::iter::zip;
 
 /// See Handbook of Applied Cryptography, Algorithm 14.32, p. 601.
@@ -13,7 +13,7 @@ pub fn mul_redc(a: &[u64], b: &[u64], result: &mut [u64], m: &[u64], inv: u64) {
     // Compute temp full product.
     // OPT: Do combined multiplication and reduction.
     let mut temp = vec![0; 2 * m.len() + 1];
-    mul(a, b, &mut temp);
+    addmul(&mut temp, a, b);
 
     // Reduce temp.
     for i in 0..m.len() {

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -226,7 +226,11 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     #[track_caller]
     pub fn from_be_bytes<const BYTES: usize>(bytes: [u8; BYTES]) -> Self {
         assert_eq!(BYTES, Self::BYTES);
-        Self::try_from_be_slice(&bytes).expect("Value too large for Uint")
+        let mut limbs = [0_u64; LIMBS];
+        for (limb, bytes) in limbs.iter_mut().zip(bytes.rchunks_exact(8)) {
+            *limb = u64::from_be_bytes(bytes.try_into().unwrap());
+        }
+        Self::from_limbs(limbs)
     }
 
     /// Converts a little-endian byte array of size exactly

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -226,11 +226,16 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     #[track_caller]
     pub fn from_be_bytes<const BYTES: usize>(bytes: [u8; BYTES]) -> Self {
         assert_eq!(BYTES, Self::BYTES);
-        let mut limbs = [0_u64; LIMBS];
-        for (limb, bytes) in limbs.iter_mut().zip(bytes.rchunks_exact(8)) {
-            *limb = u64::from_be_bytes(bytes.try_into().unwrap());
+        if BYTES % 8 == 0 {
+            // Optimized implementation for full-limb types.
+            let mut limbs = [0_u64; LIMBS];
+            for (limb, bytes) in limbs.iter_mut().zip(bytes.rchunks_exact(8)) {
+                *limb = u64::from_be_bytes(bytes.try_into().unwrap());
+            }
+            Self::from_limbs(limbs)
+        } else {
+            Self::try_from_be_slice(&bytes).unwrap()
         }
-        Self::from_limbs(limbs)
     }
 
     /// Converts a little-endian byte array of size exactly

--- a/src/modular.rs
+++ b/src/modular.rs
@@ -63,7 +63,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         // Alternatively we could use `alloca`, but that is blocked on
         // See <https://github.com/rust-lang/rust/issues/48055>
         let mut product = vec![0; nlimbs(2 * BITS)];
-        let overflow = algorithms::mul_inline(&self.limbs, &rhs.limbs, &mut product);
+        let overflow = algorithms::addmul(&mut product, &self.limbs, &rhs.limbs);
         debug_assert!(!overflow);
 
         // Compute modulus using `div_rem`.

--- a/src/mul.rs
+++ b/src/mul.rs
@@ -35,8 +35,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     #[must_use]
     pub fn overflowing_mul(self, rhs: Self) -> (Self, bool) {
         let mut result = Self::ZERO;
-        let mut overflow =
-            algorithms::mul_inline(self.as_limbs(), rhs.as_limbs(), &mut result.limbs);
+        let mut overflow = algorithms::addmul(&mut result.limbs, self.as_limbs(), rhs.as_limbs());
         if BITS > 0 {
             overflow |= result.limbs[LIMBS - 1] > Self::MASK;
             result.limbs[LIMBS - 1] &= Self::MASK;
@@ -134,7 +133,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         assert_eq!(BITS_RES, BITS + BITS_RHS);
         assert_eq!(LIMBS_RES, nlimbs(BITS_RES));
         let mut result = Uint::<BITS_RES, LIMBS_RES>::ZERO;
-        algorithms::mul_inline(&self.limbs, &rhs.limbs, &mut result.limbs);
+        algorithms::addmul(&mut result.limbs, &self.limbs, &rhs.limbs);
         if LIMBS_RES > 0 {
             debug_assert!(result.limbs[LIMBS_RES - 1] <= Uint::<BITS_RES, LIMBS_RES>::MASK);
         }

--- a/src/mul.rs
+++ b/src/mul.rs
@@ -276,9 +276,9 @@ pub mod bench {
             const LIMBS: usize = nlimbs(BITS);
             bench_mul::<BITS, LIMBS>(criterion);
         });
-        const_for!(BITS_LHS in BENCH {
+        const_for!(BITS_LHS in [64, 256,1024] {
             const LIMBS_LHS: usize = nlimbs(BITS_LHS);
-            const_for!(BITS_RHS in BENCH {
+            const_for!(BITS_RHS in [64, 256,1024] {
                 const LIMBS_RHS: usize = nlimbs(BITS_RHS);
                 const BITS_RES: usize = BITS_LHS + BITS_RHS;
                 const LIMBS_RES: usize = nlimbs(BITS_RES);

--- a/src/mul.rs
+++ b/src/mul.rs
@@ -61,7 +61,13 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     #[inline(always)]
     #[must_use]
     pub fn wrapping_mul(self, rhs: Self) -> Self {
-        self.overflowing_mul(rhs).0
+        let mut result = Self::ZERO;
+        algorithms::addmul_n(&mut result.limbs, self.as_limbs(), rhs.as_limbs());
+        if BITS > 0 {
+            result.limbs[LIMBS - 1] &= Self::MASK;
+        }
+        assert_eq!(result, self.overflowing_mul(rhs).0);
+        result
     }
 
     /// Computes the inverse modulo $2^{\mathtt{BITS}}$ of `self`, returning

--- a/src/mul.rs
+++ b/src/mul.rs
@@ -66,7 +66,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         if BITS > 0 {
             result.limbs[LIMBS - 1] &= Self::MASK;
         }
-        assert_eq!(result, self.overflowing_mul(rhs).0);
         result
     }
 


### PR DESCRIPTION
```
mul/0                   time:   [314.76 ps 316.08 ps 317.58 ps]
                        change: [-67.015% -66.814% -66.631%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

mul/64                  time:   [1.0591 ns 1.1872 ns 1.3455 ns]
                        change: [-69.394% -62.392% -52.481%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) high mild
  10 (10.00%) high severe

mul/128                 time:   [2.2009 ns 2.3544 ns 2.5397 ns]
                        change: [-74.758% -71.251% -66.321%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  11 (11.00%) high severe

mul/192                 time:   [4.4369 ns 4.6025 ns 4.7911 ns]
                        change: [-68.195% -64.799% -60.917%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  4 (4.00%) high mild
  9 (9.00%) high severe

mul/256                 time:   [4.3072 ns 4.5853 ns 4.9259 ns]
                        change: [-82.031% -80.074% -77.594%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) high mild
  10 (10.00%) high severe

mul/384                 time:   [27.068 ns 27.433 ns 27.861 ns]
                        change: [-35.527% -31.380% -26.150%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

mul/512                 time:   [51.645 ns 52.022 ns 52.454 ns]
                        change: [-37.659% -34.788% -31.447%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

mul/4096                time:   [1.9659 µs 1.9748 µs 1.9838 µs]
                        change: [-55.846% -55.497% -55.109%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

```