### PR TITLE
fix incorrect wrapping_mul doc

### DIFF
--- a/src/mul.rs
+++ b/src/mul.rs
@@ -55,8 +55,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         }
     }
 
-    /// Computes `self * rhs`, saturating at the numeric bounds instead of
-    /// overflowing.
+    /// Computes `self * rhs`, wrapping around at the boundary of the type.
     #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

`Uint::wrapping_mul` has the same rustdoc as `Uint::saturating_mul`, incorrectly stating that it saturates instead of overflowing

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
