### PR TITLE
chore: add prestwich to code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # General code
 * @recmo
+* @prestwich
 
 # CI
 .github @recmo


### PR DESCRIPTION
## Motivation

Allow me to merge PRs without weakening branch protection rules

## Solution

Add @prestwich to `CODEOWNERS`

## PR Checklist

- [n/a] Added Tests
- [n/a] Added Documentation
- [n/a] Updated the changelog
