### PR TITLE
fix: prevent overflowing instantiation in from_base_be

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fix error in `from_base_be` that allowed instantiation of overflowing `Uint`.
 - Updated `ark` to `0.4`, `fastrlp` to `0.3` and `pyo3` to `0.18`.
 
 ## [1.8.0] — 2023-04-19

--- a/src/base_convert.rs
+++ b/src/base_convert.rs
@@ -91,7 +91,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         if base < 2 {
             return Err(BaseConvertError::InvalidBase(base));
         }
-        let mut result = Uint::<BITS, LIMBS>::ZERO;
+        let mut result = Self::ZERO;
         for digit in digits {
             if digit >= base {
                 return Err(BaseConvertError::InvalidDigit(digit, base));

--- a/src/base_convert.rs
+++ b/src/base_convert.rs
@@ -91,7 +91,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         if base < 2 {
             return Err(BaseConvertError::InvalidBase(base));
         }
-        let mut result = Self::ZERO;
+        let mut result = Uint::<BITS, LIMBS>::ZERO;
         for digit in digits {
             if digit >= base {
                 return Err(BaseConvertError::InvalidDigit(digit, base));
@@ -105,10 +105,11 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
                 *limb = carry as u64;
                 carry >>= 64;
             }
-            if carry > 0 {
+            if carry > 0 || result.limbs[LIMBS - 1] > Self::MASK {
                 return Err(BaseConvertError::Overflow);
             }
         }
+
         Ok(result)
     }
 }
@@ -205,5 +206,13 @@ mod tests {
                 2372330524102404852
             ]
         );
+    }
+
+    #[test]
+    fn test_from_base_be_overflow() {
+        assert_eq!(
+            Uint::<1, 1>::from_base_be(10, [1, 0, 0u64].into_iter()),
+            Err(BaseConvertError::Overflow)
+        )
     }
 }


### PR DESCRIPTION
## Motivation

Closes #248 

## Solution

Check after conversion that the highest limb is within the mask. This reproduces the `Self::MASK` check logic within `Uint::from_limbs`

## PR Checklist

- [x] Added Tests
- [n/a] Added Documentation
- [x] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
