### PR TITLE
fix: `from_base_be` overflow

### DIFF
--- a/src/base_convert.rs
+++ b/src/base_convert.rs
@@ -105,7 +105,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
                 *limb = carry as u64;
                 carry >>= 64;
             }
-            if carry > 0 || result.limbs[LIMBS - 1] > Self::MASK {
+            if carry > 0 || (LIMBS != 0 && result.limbs[LIMBS - 1] > Self::MASK) {
                 return Err(BaseConvertError::Overflow);
             }
         }
@@ -211,7 +211,19 @@ mod tests {
     #[test]
     fn test_from_base_be_overflow() {
         assert_eq!(
-            Uint::<1, 1>::from_base_be(10, [1, 0, 0u64].into_iter()),
+            Uint::<0, 0>::from_base_be(10, [].into_iter()),
+            Ok(Uint::<0, 0>::ZERO)
+        );
+        assert_eq!(
+            Uint::<0, 0>::from_base_be(10, [0].into_iter()),
+            Ok(Uint::<0, 0>::ZERO)
+        );
+        assert_eq!(
+            Uint::<0, 0>::from_base_be(10, [1].into_iter()),
+            Err(BaseConvertError::Overflow)
+        );
+        assert_eq!(
+            Uint::<1, 1>::from_base_be(10, [1, 0, 0].into_iter()),
             Err(BaseConvertError::Overflow)
         )
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

`LIMBS` can be 0, which panics at runtime on subtraction overflow

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
