### PR TITLE
fix: `from_base_le`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix error in `from_base_be` that allowed instantiation of overflowing `Uint`.
 - Updated `ark` to `0.4`, `fastrlp` to `0.3` and `pyo3` to `0.18`.
 
+### Fixed
+
+- `from_base_le` implementation by reversing the input iterator
+
 ## [1.8.0] — 2023-04-19
 
 ### Added

--- a/src/base_convert.rs
+++ b/src/base_convert.rs
@@ -68,7 +68,8 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         base: u64,
         digits: I,
     ) -> Result<Self, BaseConvertError> {
-        let digits: Vec<_> = digits.into_iter().collect();
+        let mut digits: Vec<_> = digits.into_iter().collect();
+        digits.reverse();
         Self::from_base_be(base, digits)
     }
 
@@ -170,7 +171,7 @@ mod tests {
     ]);
 
     #[test]
-    fn test_base_le() {
+    fn test_to_base_le() {
         assert_eq!(
             Uint::<64, 1>::from(123456789)
                 .to_base_le(10)
@@ -188,8 +189,28 @@ mod tests {
             ]
         );
     }
+
     #[test]
-    fn test_base_be() {
+    fn test_from_base_le() {
+        assert_eq!(
+            Uint::<64, 1>::from_base_le(10, [9, 8, 7, 6, 5, 4, 3, 2, 1]),
+            Ok(Uint::<64, 1>::from(123456789))
+        );
+        assert_eq!(
+            Uint::<256, 4>::from_base_le(10000000000000000000_u64, [
+                2372330524102404852,
+                0534330209902435677,
+                7066324924582287843,
+                0630363884335538722,
+                9
+            ])
+            .unwrap(),
+            N
+        );
+    }
+
+    #[test]
+    fn test_to_base_be() {
         assert_eq!(
             Uint::<64, 1>::from(123456789)
                 .to_base_be(10)
@@ -205,6 +226,25 @@ mod tests {
                 0534330209902435677,
                 2372330524102404852
             ]
+        );
+    }
+
+    #[test]
+    fn test_from_base_be() {
+        assert_eq!(
+            Uint::<64, 1>::from_base_be(10, [1, 2, 3, 4, 5, 6, 7, 8, 9]),
+            Ok(Uint::<64, 1>::from(123456789))
+        );
+        assert_eq!(
+            Uint::<256, 4>::from_base_be(10000000000000000000_u64, [
+                9,
+                0630363884335538722,
+                7066324924582287843,
+                0534330209902435677,
+                2372330524102404852
+            ])
+            .unwrap(),
+            N
         );
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

The current implementation is the same as `from_base_be`.

Additionally, this patch can be applied to avoid allocating (ref #254), but it is a breaking change:

```diff
diff --git a/src/base_convert.rs b/src/base_convert.rs
index 9bc059f..f928e7d 100644
--- a/src/base_convert.rs
+++ b/src/base_convert.rs
@@ -64,13 +64,12 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// * [`BaseConvertError::InvalidDigit`] if a digit is out of range.
     /// * [`BaseConvertError::Overflow`] if the number is too large to
     /// fit.
-    pub fn from_base_le<I: IntoIterator<Item = u64>>(
-        base: u64,
-        digits: I,
-    ) -> Result<Self, BaseConvertError> {
-        let mut digits: Vec<_> = digits.into_iter().collect();
-        digits.reverse();
-        Self::from_base_be(base, digits)
+    pub fn from_base_le<I>(base: u64, digits: I) -> Result<Self, BaseConvertError>
+    where
+        I: IntoIterator<Item = u64>,
+        I::IntoIter: DoubleEndedIterator,
+    {
+        Self::from_base_be(base, digits.into_iter())
     }
 
     /// Constructs the [`Uint`] from digits in the base `base` in big-endian.
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
