### PR TITLE
Making std optional.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,7 +1687,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "sqlx-core",
- "thiserror",
+ "thiserror-core",
  "valuable",
  "zeroize",
 ]
@@ -2027,6 +2027,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-core"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d97345f6437bb2004cd58819d8a9ef8e36cdd7661c2abc4bbde0a7c40d9f497"
+dependencies = [
+ "thiserror-core-impl",
+]
+
+[[package]]
+name = "thiserror-core-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10ac1c5050e43014d16b2f94d0d2ce79e65ffdd8b38d8048f9c8f6a8a6da62ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,14 @@ license = "MIT"
 members = ["ruint-macro"]
 
 [features]
-default = []
+default = ["std"]
 bench = ["dep:criterion", "proptest", "rand"]
 dyn = ["dep:smallvec"]
 generic_const_exprs = []
 postgres = ["dep:postgres-types", "dep:bytes"]
 sqlx = ["dep:sqlx-core"]
+# no_std requires nightly rust due to use of #![feature(error_in_core)] (issue #103765)
+std = ["thiserror/std"] 
 
 [[bench]]
 name = "criterion"
@@ -51,7 +53,11 @@ smallvec = { version = "1.8.0", optional = true, features = [ "union" ] } # for 
 # HACK: (BLOCKED) sqlx requires a runtime to be specified.
 # <https://github.com/launchbadge/sqlx/issues/1627>
 sqlx-core = { version = "0.6", optional = true, features = [ "runtime-tokio-native-tls" ] }
-thiserror = "1.0"
+# thiserror does not support no-std, the PR to support it is
+# https://github.com/dtolnay/thiserror/pull/211, but I don't think it will be
+# merged until https://github.com/rust-lang/rust/issues/103765 is stabilized.
+# So, the forked thiserror with no-std support is being used instead.
+thiserror = { version = "1.0", default-features = false, package = "thiserror-core" }
 valuable = { version = "0.1.0", optional = true }
 zeroize = { version = "1.5", optional = true }
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for `#![no_std]` builds with the new `std` feature.
 - Support `bn-rs`, `serde` and `uint!` for `Bits`
 
 ### Fixed

--- a/Readme.md
+++ b/Readme.md
@@ -70,6 +70,12 @@ it in the stable version. There are a few more subtle issues that make this
 less ideal than it appears. It also looks like it may take some time before
 these nightly features are stabilized.
 
+Also, on nightly you may disable the `std` feature for `#![no_std]` support.
+Nightly is required until the stabilization of `error_in_core` (Rust issue
+[#103765][r103765]), moving the standard `Error` trait to `core`.
+
+[r103765]: https://github.com/rust-lang/rust/issues/103765
+
 ## Examples
 
 ```rust
@@ -112,8 +118,21 @@ Note that since `B` is a valid hexadecimal digit there can be ambiguity. To less
 
 ## Feature flags
 
-There is support for a number of crates. These are enabled by setting the identically
-named feature flag.
+The only feature enabled by default is `std`. Disabling it is only supported on
+nightly, and removes the dependency on the `std` crate, allowing this crate to
+be used on `#![no_std]` projects. Due to limited support for floating point
+operations in `core` (see Rust issue [#50145][r50145]), without `std` the
+following functionalities are disabled:
+ * module `log`
+ * module `pow`
+ * module `root`
+ * trait implementation `From<f32>`
+ * trait implementation `From<f64>`
+
+[r50145]: https://github.com/rust-lang/rust/issues/50145
+
+There is optional support for a number of crates. These are enabled by setting
+the identically named feature flag.
 
 * `unstable` Enable sem-ver unstable features.
 * [`rand`](https://docs.rs/rand): Implements sampling from the [`Standard`](https://docs.rs/rand/latest/rand/distributions/struct.Standard.html) distribution, i.e. [`rng.gen()`](https://docs.rs/rand/latest/rand/trait.Rng.html#method.gen).

--- a/src/algorithms/div/knuth.rs
+++ b/src/algorithms/div/knuth.rs
@@ -194,11 +194,12 @@ mod tests {
         add::{cmp, sbb_n},
         addmul,
     };
+    use alloc::{vec, vec::Vec};
+    use core::cmp::Ordering;
     use proptest::{
         collection, num, proptest,
         strategy::{Just, Strategy},
     };
-    use std::cmp::Ordering;
 
     // Basic test without exceptional paths
     #[test]

--- a/src/algorithms/div/reciprocal.rs
+++ b/src/algorithms/div/reciprocal.rs
@@ -6,7 +6,7 @@
 //! [new]: https://gmplib.org/list-archives/gmp-devel/2019-October/005590.html
 #![allow(dead_code, clippy::cast_possible_truncation, clippy::cast_lossless)]
 
-use std::num::Wrapping;
+use core::num::Wrapping;
 
 pub use self::{reciprocal_2_mg10 as reciprocal_2, reciprocal_mg10 as reciprocal};
 

--- a/src/algorithms/div/small.rs
+++ b/src/algorithms/div/small.rs
@@ -280,6 +280,7 @@ pub fn div_3x2_mg10(u21: u128, u0: u64, d: u128, v: u64) -> (u64, u128) {
 mod tests {
     use super::*;
     use crate::algorithms::addmul;
+    use alloc::{format, vec};
     use proptest::{
         collection,
         num::{u128, u64},

--- a/src/algorithms/gcd/matrix.rs
+++ b/src/algorithms/gcd/matrix.rs
@@ -333,12 +333,12 @@ impl Matrix {
 mod tests {
     use super::*;
     use crate::{const_for, nlimbs};
+    use alloc::str::FromStr;
     use core::{
         cmp::{max, min},
         mem::swap,
     };
     use proptest::{proptest, test_runner::Config};
-    use std::str::FromStr;
 
     fn gcd(mut a: u128, mut b: u128) -> u128 {
         while b != 0 {

--- a/src/algorithms/gcd/mod.rs
+++ b/src/algorithms/gcd/mod.rs
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_gcd_one() {
-        use std::str::FromStr;
+        use alloc::str::FromStr;
         const BITS: usize = 129;
         const LIMBS: usize = nlimbs(BITS);
         type U = Uint<BITS, LIMBS>;

--- a/src/algorithms/mul.rs
+++ b/src/algorithms/mul.rs
@@ -281,6 +281,7 @@ pub fn submul_nx1(lhs: &mut [u64], a: &[u64], b: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
     use proptest::{collection, num::u64, proptest};
 
     #[test]

--- a/src/algorithms/mul_redc.rs
+++ b/src/algorithms/mul_redc.rs
@@ -1,4 +1,5 @@
 use super::addmul;
+use alloc::vec;
 use core::iter::zip;
 
 /// See Handbook of Applied Cryptography, Algorithm 14.32, p. 601.

--- a/src/base_convert.rs
+++ b/src/base_convert.rs
@@ -1,4 +1,5 @@
 use crate::Uint;
+use alloc::vec::Vec;
 use thiserror::Error;
 
 /// Error for [`from_base_le`][Uint::from_base_le] and

--- a/src/bit_arr.rs
+++ b/src/bit_arr.rs
@@ -1,10 +1,10 @@
 use crate::{ParseError, Uint};
+use alloc::{borrow::Cow, vec::Vec};
 use core::ops::{
     BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Index, Not, Shl, ShlAssign,
     Shr, ShrAssign,
 };
 use derive_more::{From, FromStr, Into};
-use std::borrow::Cow;
 
 /// A newtype wrapper around [`Uint`] that restricts operations to those
 /// relevant for bit arrays.

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -5,12 +5,12 @@ use crate::{
     utils::{trim_end_slice, trim_end_vec},
     Uint,
 };
+use alloc::{borrow::Cow, vec::Vec};
 use core::{
     mem::size_of_val,
     ptr::{addr_of, addr_of_mut},
     slice,
 };
-use std::borrow::Cow;
 
 // OPT: *_to_smallvec to avoid allocation.
 

--- a/src/div.rs
+++ b/src/div.rs
@@ -82,6 +82,7 @@ impl_bin_op!(Rem, rem, RemAssign, rem_assign, wrapping_rem);
 pub mod tests {
     use super::*;
     use crate::{const_for, nlimbs};
+    use alloc::format;
     use proptest::{prop_assume, proptest};
 
     #[test]

--- a/src/from.rs
+++ b/src/from.rs
@@ -415,6 +415,7 @@ impl_from_signed_int!(i64, u64);
 impl_from_signed_int!(i128, u128);
 impl_from_signed_int!(isize, usize);
 
+#[cfg(feature = "std")]
 impl<const BITS: usize, const LIMBS: usize> TryFrom<f64> for Uint<BITS, LIMBS> {
     type Error = ToUintError<Self>;
 
@@ -483,6 +484,7 @@ impl<const BITS: usize, const LIMBS: usize> TryFrom<f64> for Uint<BITS, LIMBS> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<const BITS: usize, const LIMBS: usize> TryFrom<f32> for Uint<BITS, LIMBS> {
     type Error = ToUintError<Self>;
 
@@ -601,12 +603,14 @@ impl<const BITS: usize, const LIMBS: usize> TryFrom<&Uint<BITS, LIMBS>> for u128
 // Convert Uint to floating point
 //
 
+#[cfg(feature = "std")]
 impl<const BITS: usize, const LIMBS: usize> From<Uint<BITS, LIMBS>> for f32 {
     fn from(value: Uint<BITS, LIMBS>) -> Self {
         Self::from(&value)
     }
 }
 
+#[cfg(feature = "std")]
 impl<const BITS: usize, const LIMBS: usize> From<&Uint<BITS, LIMBS>> for f32 {
     /// Approximate single precision float.
     ///
@@ -618,12 +622,14 @@ impl<const BITS: usize, const LIMBS: usize> From<&Uint<BITS, LIMBS>> for f32 {
     }
 }
 
+#[cfg(feature = "std")]
 impl<const BITS: usize, const LIMBS: usize> From<Uint<BITS, LIMBS>> for f64 {
     fn from(value: Uint<BITS, LIMBS>) -> Self {
         Self::from(&value)
     }
 }
 
+#[cfg(feature = "std")]
 impl<const BITS: usize, const LIMBS: usize> From<&Uint<BITS, LIMBS>> for f64 {
     /// Approximate double precision float.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std, feature(error_in_core))]
 #![doc = include_str!("../Readme.md")]
 #![doc(issue_tracker_base_url = "https://github.com/recmo/uint/issues/")]
 #![warn(clippy::all, clippy::pedantic, clippy::cargo, clippy::nursery)]
@@ -26,6 +27,8 @@
 // Nightly only feature flag to enable the `unlikely` compiler hint.
 #![cfg_attr(has_core_intrinsics, feature(core_intrinsics))]
 
+extern crate alloc;
+
 // Workaround for proc-macro `uint!` in this crate.
 // See <https://github.com/rust-lang/rust/pull/55275>
 extern crate self as ruint;
@@ -42,16 +45,21 @@ mod const_for;
 mod div;
 mod from;
 mod gcd;
-mod log;
 mod modular;
 mod mul;
-mod pow;
-mod root;
 mod special;
 mod string;
 mod support;
 mod uint_dyn;
 mod utils;
+// The following math operations are disable due to lack of some floating point
+// functions in core. See issue https://github.com/rust-lang/rust/issues/50145
+#[cfg(feature = "std")]
+mod log;
+#[cfg(feature = "std")]
+mod pow;
+#[cfg(feature = "std")]
+mod root;
 
 #[cfg(all(feature = "dyn", feature = "unstable"))]
 #[doc(inline)]

--- a/src/modular.rs
+++ b/src/modular.rs
@@ -1,4 +1,5 @@
 use crate::{algorithms, nlimbs, Uint};
+use alloc::vec;
 
 // FEATURE: sub_mod, neg_mod, inv_mod, div_mod, root_mod
 // See <https://en.wikipedia.org/wiki/Cipolla's_algorithm>
@@ -169,6 +170,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
 mod tests {
     use super::*;
     use crate::{aliases::U64, const_for, nlimbs};
+    use alloc::format;
     use core::cmp::min;
     use proptest::{prop_assume, proptest, test_runner::Config};
 
@@ -289,7 +291,6 @@ mod tests {
                     // TODO: Test for larger (>= m) values of a, b.
 
                     let expected = a.mul_mod(b, m).mul_mod(r, m);
-
                     assert_eq!(ar.mul_redc(br, m, inv), expected);
                 }
             });

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -166,8 +166,8 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
 mod tests {
     use super::*;
     use crate::{const_for, nlimbs};
+    use core::iter::repeat;
     use proptest::proptest;
-    use std::iter::repeat;
 
     #[test]
     fn test_pow2_shl() {

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,8 +1,8 @@
 use crate::{base_convert::BaseConvertError, utils::rem_up, Uint};
-use core::fmt::{
-    Binary, Debug, Display, Formatter, LowerHex, Octal, Result as FmtResult, UpperHex,
+use core::{
+    fmt::{Binary, Debug, Display, Formatter, LowerHex, Octal, Result as FmtResult, UpperHex},
+    str::FromStr,
 };
-use std::str::FromStr;
 use thiserror::Error;
 
 // FEATURE: Respect width parameter in formatters.
@@ -186,6 +186,7 @@ impl<const BITS: usize, const LIMBS: usize> FromStr for Uint<BITS, LIMBS> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::{format, string::ToString};
     use proptest::proptest;
 
     #[allow(clippy::unreadable_literal)]

--- a/src/support/arbitrary.rs
+++ b/src/support/arbitrary.rs
@@ -32,7 +32,8 @@ impl<'a, const BITS: usize, const LIMBS: usize> Arbitrary<'a> for Uint<BITS, LIM
 mod tests {
     use super::*;
     use crate::{const_for, nlimbs};
-    use std::iter::repeat;
+    use alloc::vec::Vec;
+    use core::iter::repeat;
 
     #[test]
     fn test_arbitrary() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 /// Like `a % b` but returns `b` instead of `0`.
 #[must_use]
 pub const fn rem_up(a: usize, b: usize) -> usize {


### PR DESCRIPTION
This PR creates a new cargo feature `std`, on by default, that can be disabled if the user wants to target an environment with no support for `std` library.

## Motivation

Crate is now supported in a larger number of targets, and is a step into fixing this issue: https://github.com/bluealloy/revm/issues/493.

## Solution

This crate doesn't really use any std feature (e.g., threads, IO, file, network). It is a pure computation library, and theoretically it could be pure `#![no_std]` with no need for a feature to enable "std". But unfortunately I hit into two issues:
- The fact that `thiserror` is currently std-only (https://github.com/dtolnay/thiserror/pull/211), and the solution to make `thiserror` no_std depends on a unstable rust feature (https://github.com/rust-lang/rust/issues/103765).
- Some floating point functions are only available in `std` (like `log2`, `abs`, `pow`, etc), this is an issue of LLVM relying on the system libraries implementation for these functions. This also happens with `memcpy` and integer division functions, which LLVM assumes to exist, and is solved by including these functions in `compiler_builtins` library that can be used by no_std projects. For some reason, the corresponding floating point functions are not in `compiler_builtins` yet (https://github.com/rust-lang/rust/issues/50145). Thus, when `std` is disabled, this PR disables modules `log`, `pow` and `root`, along with `From<f64>` and `From<f32>` implementations, all which relies on the missing floating point functions.

## PR Checklist

- [?] Added Tests
- [✓] Added Documentation
- [✓] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
