### PR TITLE
fix: ruint-macro doctests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ harness = false
 path = "benches/bench.rs"
 
 [dependencies]
-ruint-macro = { version = "1.1.0", path = "ruint-macro" }
+ruint-macro.workspace = true
 
 thiserror = "1.0"
 

--- a/deny.toml
+++ b/deny.toml
@@ -7,7 +7,7 @@ notice = "warn"
 
 [bans]
 multiple-versions = "warn"
-wildcards = "deny"
+wildcards = "warn"
 highlight = "all"
 
 [licenses]

--- a/ruint-macro/Cargo.toml
+++ b/ruint-macro/Cargo.toml
@@ -19,3 +19,5 @@ proc-macro = true
 [package.metadata.release]
 tag = false
 
+[dev-dependencies]
+ruint = { path = ".." }

--- a/ruint-macro/README.md
+++ b/ruint-macro/README.md
@@ -27,7 +27,7 @@ The [`uint!`] macro recurses through the parse tree, so the above can equivalent
 
 ```rust
 # use ruint::uint;
-uint!{
+uint! {
 let avogadro = 602_214_076_000_000_000_000_000_U256;
 let cow_key = 0xee79b5f6e221356af78cf4c36f4f7885a11b67dfcc81c34d80249947330c0f82_U256;
 let bender = 0b1010011010_U10;
@@ -50,7 +50,7 @@ does not fit the type:
 
 ```rust,compile_fail
 # use ruint::uint;
-# uint!{
+# uint! {
 let sparta = 300_U8;
 # }
 ```

--- a/ruint-macro/tests/parse_mixed.rs
+++ b/ruint-macro/tests/parse_mixed.rs
@@ -1,7 +1,5 @@
-use ruint::{
-    aliases::{B256, U256},
-    uint,
-};
+use ruint::aliases::{B256, U256};
+use ruint_macro::uint;
 
 #[test]
 fn test_non_literal() {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

> [Note: [...] path dev-dependencies are ignored](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-path-dependencies
)

This should work with cargo-release

Partly reverts #268

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
