### PR TITLE
feat: no_std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for `no_std` environments (#274)
+
+[#274]: https://github.com/recmo/uint/pulls/274
+
 ## [1.9.0] - 2023-07-25
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,6 @@ serde_json = "1.0"
 [features]
 default = ["std"]
 std = [
-    "thiserror",
     "alloy-rlp?/std",
     "ark-ff-03?/std",
     "ark-ff-04?/std",
@@ -135,5 +134,5 @@ serde = ["dep:serde"]
 valuable = ["dep:valuable"]
 zeroize = ["dep:zeroize"]
 
-postgres = ["dep:postgres-types", "dep:bytes", "std"]
-sqlx = ["dep:sqlx-core", "std"]
+postgres = ["dep:postgres-types", "dep:bytes", "std", "dep:thiserror"]
+sqlx = ["dep:sqlx-core", "std", "dep:thiserror"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,30 +38,34 @@ ruint-macro = { version = "1.1.0", path = "ruint-macro" }
 name = "bench_uint"
 harness = false
 path = "benches/bench.rs"
+required-features = ["std"]
 
 [dependencies]
 ruint-macro.workspace = true
 
-thiserror = "1.0"
+thiserror = { version = "1.0", optional = true }
 
 # support
-alloy-rlp = { version = "0.3", optional = true }
-arbitrary = { version = "1", optional = true }
-ark-ff-04 = { version = "0.4.0", package = "ark-ff", optional = true }
-ark-ff-03 = { version = "0.3.0", package = "ark-ff", optional = true }
-bn-rs = { version = "0.2", optional = true }
-fastrlp = { version = "0.3", optional = true }
-num-bigint = { version = "0.4", optional = true }
-parity-scale-codec = { version = "3", optional = true, features = ["derive", "max-encoded-len"] }
-primitive-types = { version = "0.12", optional = true }
-proptest = { version = "1", optional = true }
-pyo3 = { version = "0.19", optional = true }
-quickcheck = { version = "1", optional = true }
-rand = { version = "0.8", optional = true }
-rlp = { version = "0.5", optional = true }
-serde = { version = "1", optional = true }
-valuable = { version = "0.1", optional = true }
-zeroize = { version = "1.6", optional = true }
+alloy-rlp = { version = "0.3", optional = true, default-features = false }
+arbitrary = { version = "1", optional = true, default-features = false }
+ark-ff-03 = { version = "0.3.0", package = "ark-ff", optional = true, default-features = false }
+ark-ff-04 = { version = "0.4.0", package = "ark-ff", optional = true, default-features = false }
+bn-rs = { version = "0.2", optional = true, default-features = true }
+fastrlp = { version = "0.3", optional = true, default-features = false }
+num-bigint = { version = "0.4", optional = true, default-features = false }
+parity-scale-codec = { version = "3", optional = true, features = [
+    "derive",
+    "max-encoded-len",
+], default-features = false }
+primitive-types = { version = "0.12", optional = true, default-features = false }
+proptest = { version = "1", optional = true, default-features = false }
+pyo3 = { version = "0.19", optional = true, default-features = false }
+quickcheck = { version = "1", optional = true, default-features = false }
+rand = { version = "0.8", optional = true, default-features = false }
+rlp = { version = "0.5", optional = true, default-features = false }
+serde = { version = "1", optional = true, default-features = false }
+valuable = { version = "0.1", optional = true, default-features = false }
+zeroize = { version = "1.6", optional = true, default-features = false }
 
 # postgres
 bytes = { version = "1.4", optional = true }
@@ -73,8 +77,8 @@ sqlx-core = { version = "0.7", optional = true }
 [dev-dependencies]
 ruint = { workspace = true, features = ["arbitrary", "proptest"] }
 
-ark-bn254-04 = { version = "0.4.0", package = "ark-bn254" }
 ark-bn254-03 = { version = "0.3.0", package = "ark-bn254" }
+ark-bn254-04 = { version = "0.4.0", package = "ark-bn254" }
 
 criterion = "0.5"
 rand = "0.8"
@@ -89,28 +93,47 @@ proptest = "1.2"
 serde_json = "1.0"
 
 [features]
+default = ["std"]
+std = [
+    "thiserror",
+    "alloy-rlp?/std",
+    "ark-ff-03?/std",
+    "ark-ff-04?/std",
+    "bytes?/std",
+    "fastrlp?/std",
+    "num-bigint?/std",
+    "parity-scale-codec?/std",
+    "primitive-types?/std",
+    "proptest?/std",
+    "rand?/std",
+    "rlp?/std",
+    "serde?/std",
+    "valuable?/std",
+    "zeroize?/std",
+]
+
 # nightly-only features
 nightly = []
 generic_const_exprs = ["nightly"]
 
 # support
 alloy-rlp = ["dep:alloy-rlp"]
-arbitrary = ["dep:arbitrary"]
+arbitrary = ["dep:arbitrary", "std"]
 ark-ff = ["dep:ark-ff-03"]
 ark-ff-04 = ["dep:ark-ff-04"]
-bn-rs = ["dep:bn-rs"]
+bn-rs = ["dep:bn-rs", "std"]
 fastrlp = ["dep:fastrlp"]
 num-bigint = ["dep:num-bigint"]
 parity-scale-codec = ["dep:parity-scale-codec"]
 primitive-types = ["dep:primitive-types"]
 proptest = ["dep:proptest"]
-pyo3 = ["dep:pyo3"]
-quickcheck = ["dep:quickcheck"]
+pyo3 = ["dep:pyo3", "std"]
+quickcheck = ["dep:quickcheck", "std"]
 rand = ["dep:rand"]
 rlp = ["dep:rlp"]
 serde = ["dep:serde"]
 valuable = ["dep:valuable"]
 zeroize = ["dep:zeroize"]
 
-postgres = ["dep:postgres-types", "dep:bytes"]
-sqlx = ["dep:sqlx-core"]
+postgres = ["dep:postgres-types", "dep:bytes", "std"]
+sqlx = ["dep:sqlx-core", "std"]

--- a/benches/benches/algorithms/gcd.rs
+++ b/benches/benches/algorithms/gcd.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
+use core::cmp::{max, min};
 use ruint::algorithms::LehmerMatrix as Matrix;
-use std::cmp::{max, min};
 
 pub fn group(criterion: &mut Criterion) {
     bench_from_u64(criterion);

--- a/ruint-macro/src/lib.rs
+++ b/ruint-macro/src/lib.rs
@@ -1,11 +1,11 @@
 #![doc = include_str!("../README.md")]
 #![warn(clippy::all, clippy::pedantic, clippy::cargo, clippy::nursery)]
 
-use proc_macro::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
-use std::{
+use core::{
     fmt::{Display, Formatter, Write},
     str::FromStr,
 };
+use proc_macro::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 enum LiteralBaseType {

--- a/src/algorithms/div/knuth.rs
+++ b/src/algorithms/div/knuth.rs
@@ -194,11 +194,12 @@ mod tests {
         add::{cmp, sbb_n},
         addmul,
     };
+    use alloc::vec::Vec;
+    use core::cmp::Ordering;
     use proptest::{
         collection, num, proptest,
         strategy::{Just, Strategy},
     };
-    use std::cmp::Ordering;
 
     // Basic test without exceptional paths
     #[test]

--- a/src/algorithms/div/reciprocal.rs
+++ b/src/algorithms/div/reciprocal.rs
@@ -6,7 +6,7 @@
 //! [new]: https://gmplib.org/list-archives/gmp-devel/2019-October/005590.html
 #![allow(dead_code, clippy::cast_possible_truncation, clippy::cast_lossless)]
 
-use std::num::Wrapping;
+use core::num::Wrapping;
 
 pub use self::{reciprocal_2_mg10 as reciprocal_2, reciprocal_mg10 as reciprocal};
 

--- a/src/algorithms/gcd/matrix.rs
+++ b/src/algorithms/gcd/matrix.rs
@@ -336,9 +336,9 @@ mod tests {
     use core::{
         cmp::{max, min},
         mem::swap,
+        str::FromStr,
     };
     use proptest::{proptest, test_runner::Config};
-    use std::str::FromStr;
 
     fn gcd(mut a: u128, mut b: u128) -> u128 {
         while b != 0 {

--- a/src/algorithms/gcd/mod.rs
+++ b/src/algorithms/gcd/mod.rs
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_gcd_one() {
-        use std::str::FromStr;
+        use core::str::FromStr;
         const BITS: usize = 129;
         const LIMBS: usize = nlimbs(BITS);
         type U = Uint<BITS, LIMBS>;

--- a/src/bit_arr.rs
+++ b/src/bit_arr.rs
@@ -1,9 +1,12 @@
 use crate::{ParseError, Uint};
-use core::ops::{
-    BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Index, Not, Shl, ShlAssign,
-    Shr, ShrAssign,
+use alloc::{borrow::Cow, vec::Vec};
+use core::{
+    ops::{
+        BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Index, Not, Shl, ShlAssign,
+        Shr, ShrAssign,
+    },
+    str::FromStr,
 };
-use std::{borrow::Cow, str::FromStr};
 
 /// A newtype wrapper around [`Uint`] that restricts operations to those
 /// relevant for bit arrays.

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -5,11 +5,11 @@ use crate::{
     utils::{trim_end_slice, trim_end_vec},
     Uint,
 };
+use alloc::{borrow::Cow, vec::Vec};
 use core::{
     ptr::{addr_of, addr_of_mut},
     slice,
 };
-use std::borrow::Cow;
 
 // OPT: *_to_smallvec to avoid allocation.
 impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {

--- a/src/from.rs
+++ b/src/from.rs
@@ -59,10 +59,13 @@ impl<T> fmt::Display for ToUintError<T> {
         match self {
             Self::ValueTooLarge(bits, _) => write!(f, "Value is too large for Uint<{bits}>"),
             Self::ValueNegative(bits, _) => {
-                write!(f, "Negative values can not be represented as Uint<{bits}>")
+                write!(f, "Negative values cannot be represented as Uint<{bits}>")
             }
             Self::NotANumber(bits) => {
-                write!(f, "'Not a number' (NaN) not be represented as Uint<{bits}>")
+                write!(
+                    f,
+                    "'Not a number' (NaN) cannot be represented as Uint<{bits}>"
+                )
             }
         }
     }

--- a/src/from.rs
+++ b/src/from.rs
@@ -32,49 +32,88 @@
 // }
 
 use crate::Uint;
-use core::{any::type_name, fmt::Debug};
-use thiserror::Error;
+use core::{fmt, fmt::Debug};
 
 /// Error for [`TryFrom<T>`][TryFrom] for [`Uint`].
-#[derive(Clone, Copy, Debug, Error, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum ToUintError<T> {
     /// Value is too large to fit the Uint.
     ///
     /// `.0` is `BITS` and `.1` is the wrapped value.
-    #[error("Value is too large for Uint<{0}>")]
     ValueTooLarge(usize, T),
 
     /// Negative values can not be represented as Uint.
     ///
     /// `.0` is `BITS` and `.1` is the wrapped value.
-    #[error("Negative values can not be represented as Uint<{0}>")]
     ValueNegative(usize, T),
 
     /// 'Not a number' (NaN) can not be represented as Uint
-    #[error("'Not a number' (NaN) not be represented as Uint<{0}>")]
     NotANumber(usize),
+}
+
+#[cfg(feature = "std")]
+impl<T: fmt::Debug> std::error::Error for ToUintError<T> {}
+
+impl<T> fmt::Display for ToUintError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ValueTooLarge(bits, _) => write!(f, "Value is too large for Uint<{bits}>"),
+            Self::ValueNegative(bits, _) => {
+                write!(f, "Negative values can not be represented as Uint<{bits}>")
+            }
+            Self::NotANumber(bits) => {
+                write!(f, "'Not a number' (NaN) not be represented as Uint<{bits}>")
+            }
+        }
+    }
 }
 
 /// Error for [`TryFrom<Uint>`][TryFrom].
 #[allow(clippy::derive_partial_eq_without_eq)] // False positive
-#[derive(Clone, Copy, Debug, Error, PartialEq, Eq, Hash)]
 #[allow(clippy::module_name_repetitions)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum FromUintError<T> {
     /// The Uint value is too large for the target type.
     ///
     /// `.0` number of `BITS` in the Uint, `.1` is the wrapped value and
     /// `.2` is the maximum representable value in the target type.
-    #[error("Uint<{0}> value is too large for {}", type_name::<T>())]
     Overflow(usize, T, T),
+}
+
+#[cfg(feature = "std")]
+impl<T: fmt::Debug> std::error::Error for FromUintError<T> {}
+
+impl<T> fmt::Display for FromUintError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Overflow(bits, ..) => write!(
+                f,
+                "Uint<{bits}> value is too large for {}",
+                core::any::type_name::<T>()
+            ),
+        }
+    }
 }
 
 /// Error for [`TryFrom<Uint>`][TryFrom] for [`ark_ff`](https://docs.rs/ark-ff) and others.
 #[allow(dead_code)] // This is used by some support features.
-#[derive(Debug, Clone, Copy, Error)]
+#[derive(Debug, Clone, Copy)]
 pub enum ToFieldError {
     /// Number is equal or larger than the target field modulus.
-    #[error("Number is equal or larger than the target field modulus.")]
     NotInField,
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ToFieldError {}
+
+impl fmt::Display for ToFieldError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotInField => {
+                f.write_str("Number is equal or larger than the target field modulus.")
+            }
+        }
+    }
 }
 
 impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
@@ -418,6 +457,7 @@ impl_from_signed_int!(i64, u64);
 impl_from_signed_int!(i128, u128);
 impl_from_signed_int!(isize, usize);
 
+#[cfg(feature = "std")]
 impl<const BITS: usize, const LIMBS: usize> TryFrom<f64> for Uint<BITS, LIMBS> {
     type Error = ToUintError<Self>;
 
@@ -486,6 +526,7 @@ impl<const BITS: usize, const LIMBS: usize> TryFrom<f64> for Uint<BITS, LIMBS> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<const BITS: usize, const LIMBS: usize> TryFrom<f32> for Uint<BITS, LIMBS> {
     type Error = ToUintError<Self>;
 
@@ -605,12 +646,14 @@ impl<const BITS: usize, const LIMBS: usize> TryFrom<&Uint<BITS, LIMBS>> for u128
 
 // Convert Uint to floating point
 
+#[cfg(feature = "std")]
 impl<const BITS: usize, const LIMBS: usize> From<Uint<BITS, LIMBS>> for f32 {
     fn from(value: Uint<BITS, LIMBS>) -> Self {
         Self::from(&value)
     }
 }
 
+#[cfg(feature = "std")]
 impl<const BITS: usize, const LIMBS: usize> From<&Uint<BITS, LIMBS>> for f32 {
     /// Approximate single precision float.
     ///
@@ -622,12 +665,14 @@ impl<const BITS: usize, const LIMBS: usize> From<&Uint<BITS, LIMBS>> for f32 {
     }
 }
 
+#[cfg(feature = "std")]
 impl<const BITS: usize, const LIMBS: usize> From<Uint<BITS, LIMBS>> for f64 {
     fn from(value: Uint<BITS, LIMBS>) -> Self {
         Self::from(&value)
     }
 }
 
+#[cfg(feature = "std")]
 impl<const BITS: usize, const LIMBS: usize> From<&Uint<BITS, LIMBS>> for f64 {
     /// Approximate double precision float.
     ///
@@ -659,6 +704,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_f64() {
         assert_eq!(Uint::<0, 0>::try_from(0.0_f64), Ok(Uint::ZERO));
         const_for!(BITS in NON_ZERO {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
     any(test, feature = "bench"),
     allow(clippy::wildcard_imports, clippy::cognitive_complexity)
 )]
+#![cfg_attr(not(feature = "std"), no_std)]
 // Unstable features
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(feature = "nightly", feature(no_coverage, core_intrinsics))]
@@ -25,6 +26,10 @@
 // Workaround for proc-macro `uint!` in this crate.
 // See <https://github.com/rust-lang/rust/pull/55275>
 extern crate self as ruint;
+
+// TODO: alloc feature flag
+#[macro_use]
+extern crate alloc;
 
 #[macro_use]
 mod macros;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "std")]
+
 use crate::Uint;
 
 impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -118,6 +118,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// assert_eq!(U64::approx_pow2(10.385), Some(1337_U64));
     /// # }
     /// ```
+    #[cfg(feature = "std")]
     #[must_use]
     pub fn approx_pow2(exp: f64) -> Option<Self> {
         const LN2_1P5: f64 = 0.584_962_500_721_156_2_f64;
@@ -166,8 +167,8 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
 mod tests {
     use super::*;
     use crate::{const_for, nlimbs};
+    use core::iter::repeat;
     use proptest::proptest;
-    use std::iter::repeat;
 
     #[test]
     fn test_pow2_shl() {

--- a/src/root.rs
+++ b/src/root.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "std")]
+
 use crate::Uint;
 use core::cmp::{min, Ordering};
 

--- a/src/support/arbitrary.rs
+++ b/src/support/arbitrary.rs
@@ -34,7 +34,8 @@ impl<'a, const BITS: usize, const LIMBS: usize> Arbitrary<'a> for Uint<BITS, LIM
 mod tests {
     use super::*;
     use crate::{const_for, nlimbs};
-    use std::iter::repeat;
+    use alloc::vec::Vec;
+    use core::iter::repeat;
 
     #[test]
     fn test_arbitrary() {

--- a/src/support/pyo3.rs
+++ b/src/support/pyo3.rs
@@ -24,11 +24,11 @@
 #![cfg_attr(docsrs, doc(cfg(feature = "pyo3")))]
 
 use crate::Uint;
+use core::ffi::c_uchar;
 use pyo3::{
     exceptions::PyOverflowError, ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyErr, PyObject,
     PyResult, Python, ToPyObject,
 };
-use std::ffi::c_uchar;
 
 impl<const BITS: usize, const LIMBS: usize> ToPyObject for Uint<BITS, LIMBS> {
     fn to_object(&self, py: Python<'_>) -> PyObject {

--- a/src/support/rlp.rs
+++ b/src/support/rlp.rs
@@ -4,8 +4,8 @@
 #![cfg_attr(docsrs, doc(cfg(feature = "rlp")))]
 
 use crate::{Bits, Uint};
+use core::cmp::Ordering;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::cmp::Ordering;
 
 /// Allows a [`Uint`] to be serialized as RLP.
 ///

--- a/src/support/serde.rs
+++ b/src/support/serde.rs
@@ -4,12 +4,14 @@
 #![cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 
 use crate::{nbytes, Bits, Uint};
-use core::fmt::{Formatter, Result as FmtResult};
+use core::{
+    fmt::{Formatter, Result as FmtResult, Write},
+    str,
+};
 use serde::{
     de::{Error, Unexpected, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::{fmt::Write, str};
 
 /// Canonical serialization for all human-readable instances of `Uint<0, 0>`,
 /// and minimal human-readable `Uint<BITS, LIMBS>::ZERO` for any bit size.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 /// Like `a % b` but returns `b` instead of `0`.
 #[must_use]
 pub(crate) const fn rem_up(a: usize, b: usize) -> usize {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

Make `ruint` `no_std`-compatible.

Supersedes #260.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

See original description in #260.
Since `core::error::Error` is unstable, we instead implement the formatting using `core::fmt` and gate `impl std::error::Error` with `#[cfg(feature = "std")]`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
