### PR TITLE
feat: alloc feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support for `no_std` environments (#274)
+- Support for `no_std` environments ([#274])
+- `alloc` feature ([#277])
 
 [#274]: https://github.com/recmo/uint/pulls/274
+[#277]: https://github.com/recmo/uint/pulls/277
 
 ## [1.9.0] - 2023-07-25
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ arbitrary = { version = "1", optional = true, default-features = false }
 ark-ff-03 = { version = "0.3.0", package = "ark-ff", optional = true, default-features = false }
 ark-ff-04 = { version = "0.4.0", package = "ark-ff", optional = true, default-features = false }
 bn-rs = { version = "0.2", optional = true, default-features = true }
-fastrlp = { version = "0.3", optional = true, default-features = false }
+fastrlp = { version = "0.3", optional = true, default-features = false, features = ["alloc"] }
 num-bigint = { version = "0.4", optional = true, default-features = false }
 parity-scale-codec = { version = "3", optional = true, features = [
     "derive",
@@ -95,6 +95,7 @@ serde_json = "1.0"
 [features]
 default = ["std"]
 std = [
+    "alloc",
     "alloy-rlp?/std",
     "ark-ff-03?/std",
     "ark-ff-04?/std",
@@ -110,22 +111,23 @@ std = [
     "valuable?/std",
     "zeroize?/std",
 ]
+alloc = ["proptest?/alloc", "rand?/alloc", "serde?/alloc", "valuable?/alloc", "zeroize?/alloc"]
 
 # nightly-only features
 nightly = []
 generic_const_exprs = ["nightly"]
 
 # support
-alloy-rlp = ["dep:alloy-rlp"]
+alloy-rlp = ["dep:alloy-rlp", "alloc"]
 arbitrary = ["dep:arbitrary", "std"]
 ark-ff = ["dep:ark-ff-03"]
 ark-ff-04 = ["dep:ark-ff-04"]
 bn-rs = ["dep:bn-rs", "std"]
-fastrlp = ["dep:fastrlp"]
-num-bigint = ["dep:num-bigint"]
-parity-scale-codec = ["dep:parity-scale-codec"]
+fastrlp = ["dep:fastrlp", "alloc"]
+num-bigint = ["dep:num-bigint", "alloc"]
+parity-scale-codec = ["dep:parity-scale-codec", "alloc"]
 primitive-types = ["dep:primitive-types"]
-proptest = ["dep:proptest"]
+proptest = ["dep:proptest", "alloc"]
 pyo3 = ["dep:pyo3", "std"]
 quickcheck = ["dep:quickcheck", "std"]
 rand = ["dep:rand"]

--- a/src/add.rs
+++ b/src/add.rs
@@ -52,7 +52,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         }
     }
 
-    #[allow(clippy::doc_markdown)]
     /// Calculates $\mod{\mathtt{self} + \mathtt{rhs}}_{2^{BITS}}$.
     ///
     /// Returns a tuple of the addition along with a boolean indicating whether
@@ -88,7 +87,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         Self::ZERO.overflowing_sub(self)
     }
 
-    #[allow(clippy::doc_markdown)]
     /// Calculates $\mod{\mathtt{self} - \mathtt{rhs}}_{2^{BITS}}$.
     ///
     /// Returns a tuple of the subtraction along with a boolean indicating

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -7,6 +7,7 @@ mod add;
 pub mod div;
 mod gcd;
 mod mul;
+#[cfg(feature = "alloc")] // TODO: Make mul_redc alloc-free
 mod mul_redc;
 mod ops;
 mod shift;
@@ -16,10 +17,11 @@ pub use self::{
     div::div,
     gcd::{gcd, gcd_extended, inv_mod, LehmerMatrix},
     mul::{add_nx1, addmul, addmul_n, addmul_nx1, addmul_ref, submul_nx1},
-    mul_redc::mul_redc,
     ops::{adc, sbb},
     shift::{shift_left_small, shift_right_small},
 };
+#[cfg(feature = "alloc")]
+pub use mul_redc::mul_redc;
 
 trait DoubleWord<T>: Sized + Copy {
     fn join(high: T, low: T) -> Self;

--- a/src/base_convert.rs
+++ b/src/base_convert.rs
@@ -127,7 +127,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
 
         let mut tail = digits.into_iter();
         match tail.next() {
-            Some(digit) => Self::from_base_le_recurse::<I>(digit, base, tail),
+            Some(digit) => Self::from_base_le_recurse(digit, base, &mut tail),
             None => Ok(Self::ZERO),
         }
     }
@@ -138,10 +138,10 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// same construction loop as [`Uint::from_base_be`] while exiting the
     /// recursive callstack.
     #[inline]
-    fn from_base_le_recurse<I: IntoIterator<Item = u64>>(
+    fn from_base_le_recurse<I: Iterator<Item = u64>>(
         digit: u64,
         base: u64,
-        mut tail: I::IntoIter,
+        tail: &mut I,
     ) -> Result<Self, BaseConvertError> {
         if digit > base {
             return Err(BaseConvertError::InvalidDigit(digit, base));
@@ -184,6 +184,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         Ok(result)
     }
 }
+
 struct SpigotLittle<const LIMBS: usize> {
     base:  u64,
     limbs: [u64; LIMBS],

--- a/src/bit_arr.rs
+++ b/src/bit_arr.rs
@@ -1,5 +1,4 @@
 use crate::{ParseError, Uint};
-use alloc::{borrow::Cow, vec::Vec};
 use core::{
     ops::{
         BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Index, Not, Shl, ShlAssign,
@@ -7,6 +6,9 @@ use core::{
     },
     str::FromStr,
 };
+
+#[cfg(feature = "alloc")]
+use alloc::{borrow::Cow, vec::Vec};
 
 /// A newtype wrapper around [`Uint`] that restricts operations to those
 /// relevant for bit arrays.
@@ -206,11 +208,14 @@ impl<const BITS: usize, const LIMBS: usize> Bits<BITS, LIMBS> {
     forward! {
         fn reverse_bits(self) -> Self;
     }
+    #[cfg(feature = "alloc")]
     forward! {
         fn as_le_bytes(&self) -> Cow<'_, [u8]>;
+        fn to_be_bytes_vec(&self) -> Vec<u8>;
+    }
+    forward! {
         fn to_le_bytes<const BYTES: usize>(&self) -> [u8; BYTES];
         fn to_be_bytes<const BYTES: usize>(&self) -> [u8; BYTES];
-        fn to_be_bytes_vec(&self) -> Vec<u8>;
         fn leading_zeros(&self) -> usize;
         fn leading_ones(&self) -> usize;
         fn trailing_zeros(&self) -> usize;

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -248,7 +248,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         }
     }
 
-    #[allow(clippy::doc_markdown)]
     /// Left shift by `rhs` bits with overflow detection.
     ///
     /// Returns $\mod{\mathtt{value} ⋅ 2^{\mathtt{rhs}}}_{2^{\mathtt{BITS}}}$.
@@ -309,7 +308,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         (self, overflow)
     }
 
-    #[allow(clippy::doc_markdown)]
     /// Left shift by `rhs` bits.
     ///
     /// Returns $\mod{\mathtt{value} ⋅ 2^{\mathtt{rhs}}}_{2^{\mathtt{BITS}}}$.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 // See <https://github.com/rust-lang/rust/pull/55275>
 extern crate self as ruint;
 
-// TODO: alloc feature flag
+#[cfg(feature = "alloc")]
 #[macro_use]
 extern crate alloc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
     clippy::redundant_pub_crate,
     clippy::unreadable_literal,
     clippy::let_unit_value,
+    clippy::option_if_let_else,
 )]
 #![cfg_attr(
     any(test, feature = "bench"),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,3 @@
-use alloc::vec::Vec;
-
 /// Like `a % b` but returns `b` instead of `0`.
 #[must_use]
 pub(crate) const fn rem_up(a: usize, b: usize) -> usize {
@@ -11,20 +9,19 @@ pub(crate) const fn rem_up(a: usize, b: usize) -> usize {
     }
 }
 
-#[must_use]
-pub(crate) fn trim_end_slice<'a, T: PartialEq>(slice: &'a [T], value: &T) -> &'a [T] {
-    slice
-        .iter()
-        .rposition(|b| b != value)
-        .map_or_else(|| &slice[..0], |len| &slice[..=len])
+fn last_idx<T: PartialEq>(x: &[T], value: &T) -> Option<usize> {
+    x.iter().rposition(|b| b != value)
 }
 
+#[must_use]
+#[inline]
+pub(crate) fn trim_end_slice<'a, T: PartialEq>(slice: &'a [T], value: &T) -> &'a [T] {
+    &slice[..last_idx(slice, value).unwrap_or(0)]
+}
+
+#[inline]
 pub(crate) fn trim_end_vec<T: PartialEq>(vec: &mut Vec<T>, value: &T) {
-    if let Some(last) = vec.iter().rposition(|b| b != value) {
-        vec.truncate(last + 1);
-    } else {
-        vec.clear();
-    }
+    vec.truncate(last_idx(vec, value).map_or(0, |idx| idx + 1));
 }
 
 // Branch prediction hints.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
 /// Like `a % b` but returns `b` instead of `0`.
 #[must_use]
 pub(crate) const fn rem_up(a: usize, b: usize) -> usize {
@@ -9,19 +12,23 @@ pub(crate) const fn rem_up(a: usize, b: usize) -> usize {
     }
 }
 
-fn last_idx<T: PartialEq>(x: &[T], value: &T) -> Option<usize> {
-    x.iter().rposition(|b| b != value)
+#[allow(dead_code)]
+#[inline]
+fn last_idx<T: PartialEq>(x: &[T], value: &T) -> usize {
+    x.iter().rposition(|b| b != value).map_or(0, |idx| idx + 1)
 }
 
+#[allow(dead_code)]
 #[must_use]
 #[inline]
 pub(crate) fn trim_end_slice<'a, T: PartialEq>(slice: &'a [T], value: &T) -> &'a [T] {
-    &slice[..last_idx(slice, value).unwrap_or(0)]
+    &slice[..last_idx(slice, value)]
 }
 
+#[cfg(feature = "alloc")]
 #[inline]
 pub(crate) fn trim_end_vec<T: PartialEq>(vec: &mut Vec<T>, value: &T) {
-    vec.truncate(last_idx(vec, value).map_or(0, |idx| idx + 1));
+    vec.truncate(last_idx(vec, value));
 }
 
 // Branch prediction hints.
@@ -51,4 +58,32 @@ pub(crate) const fn unlikely(b: bool) -> bool {
         cold();
     }
     b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_trim() {
+        assert_eq!(trim_end_slice(&[], &0), &[] as &[i32]);
+        assert_eq!(trim_end_slice(&[0], &0), &[] as &[i32]);
+        assert_eq!(trim_end_slice(&[0, 1], &0), &[0, 1]);
+        assert_eq!(trim_end_slice(&[0, 1, 0], &0), &[0, 1]);
+        assert_eq!(trim_end_slice(&[0, 1, 0, 0], &0), &[0, 1]);
+        assert_eq!(trim_end_slice(&[0, 1, 0, 0, 0], &0), &[0, 1]);
+        assert_eq!(trim_end_slice(&[0, 1, 0, 1, 0], &0), &[0, 1, 0, 1]);
+
+        let trim_end_vec = |mut v: Vec<i32>, x: &i32| {
+            trim_end_vec(&mut v, x);
+            v
+        };
+        assert_eq!(trim_end_vec(vec![], &0), &[] as &[i32]);
+        assert_eq!(trim_end_vec(vec![0], &0), &[] as &[i32]);
+        assert_eq!(trim_end_vec(vec![0, 1], &0), &[0, 1]);
+        assert_eq!(trim_end_vec(vec![0, 1, 0], &0), &[0, 1]);
+        assert_eq!(trim_end_vec(vec![0, 1, 0, 0], &0), &[0, 1]);
+        assert_eq!(trim_end_vec(vec![0, 1, 0, 0, 0], &0), &[0, 1]);
+        assert_eq!(trim_end_vec(vec![0, 1, 0, 1, 0], &0), &[0, 1, 0, 1]);
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

Closes #275
Closes #276

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Feature gate certain functions to `"alloc"`, which is enabled by default through `"std"`.
Unfortunately most of these cannot be alloc-free themselves, because of limitations in the Rust const generics (e.g. generic const exprs).

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
