### PR TITLE
feat: check from base len to prevent consuming large iters

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -255,4 +255,9 @@ mod tests {
             assert_eq!(format!("{n:#b}"), format!("{value:#066b}"));
         });
     }
+
+    #[test]
+    fn test_from_hex_extra_zeroes() {
+        Uint::<16, 1>::from_str("0x00000000000001").unwrap();
+    }
 }


### PR DESCRIPTION
Draft PR for discussion purposes:

## Motivation

closes #279

Currently both `from_base_be` and `from_base_le` accept more digits then can fit in the target `Uint`. This leads to extra iteration/recursion. If all extra digits are 0, there is unbounded extra iteration/recursion, which results in degenerate cases:

```
// infinite loop
Uint::<4, 1>::from_base_be(10, std::iter::repeat(0u64))

// overflows the stack due to recursion
Uint::<4, 1>::from_base_le(10, std::iter::repeat(0u64))
```

## Solution

Compute `max_digits` and bound the `from_base_*e` logic to operating on that many digits. Overflow if more digits are supplied.

However, this is a **breaking change**, as `from_base_be` is used in `from_str_radix` and `from_str`, and currently permits non-minimal string encodings. 

```
Uint::<16, 1>::from_str("0x00000000000001").unwrap();
```

**Open Question:**
Can we both
- allow non-minimal byte encodings (where all extra bytes are 0)
- avoid infinite iteration

**Possible solutions:**
- use `size_hint` on the iterators, and error if no upper bound established
- allow up to `N` extra 0s in addition to the meaningful digits. Error if more than `N`

These would still be breaking, but only in much more rare cases. And we would probably be comfortable doing that as a patch

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
