### PR TITLE
Feat: Implement `Pod` trait on Uint types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `bytemuck` feature ([#292])
+
 ## [1.10.1] - 2023-07-30
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ postgres-types = { version = "0.2", optional = true }
 
 # sqlx
 sqlx-core = { version = "0.7", optional = true }
+bytemuck = "1.13.1"
 
 [dev-dependencies]
 ruint = { path = ".", features = ["arbitrary", "proptest"] }
@@ -90,23 +91,7 @@ serde_json = "1.0"
 
 [features]
 default = ["std"]
-std = [
-    "alloc",
-    "alloy-rlp?/std",
-    "ark-ff-03?/std",
-    "ark-ff-04?/std",
-    "bytes?/std",
-    "fastrlp?/std",
-    "num-bigint?/std",
-    "parity-scale-codec?/std",
-    "primitive-types?/std",
-    "proptest?/std",
-    "rand?/std",
-    "rlp?/std",
-    "serde?/std",
-    "valuable?/std",
-    "zeroize?/std",
-]
+std = ["alloc", "alloy-rlp?/std", "ark-ff-03?/std", "ark-ff-04?/std", "bytes?/std", "fastrlp?/std", "num-bigint?/std", "parity-scale-codec?/std", "primitive-types?/std", "proptest?/std", "rand?/std", "rlp?/std", "serde?/std", "valuable?/std", "zeroize?/std"]
 alloc = ["proptest?/alloc", "rand?/alloc", "serde?/alloc", "valuable?/alloc", "zeroize?/alloc"]
 
 # nightly-only features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,23 @@ serde_json = "1.0"
 
 [features]
 default = ["std"]
-std = ["alloc", "alloy-rlp?/std", "ark-ff-03?/std", "ark-ff-04?/std", "bytes?/std", "fastrlp?/std", "num-bigint?/std", "parity-scale-codec?/std", "primitive-types?/std", "proptest?/std", "rand?/std", "rlp?/std", "serde?/std", "valuable?/std", "zeroize?/std"]
+std = [
+    "alloc",
+    "alloy-rlp?/std",
+    "ark-ff-03?/std",
+    "ark-ff-04?/std",
+    "bytes?/std",
+    "fastrlp?/std",
+    "num-bigint?/std",
+    "parity-scale-codec?/std",
+    "primitive-types?/std",
+    "proptest?/std",
+    "rand?/std",
+    "rlp?/std",
+    "serde?/std",
+    "valuable?/std",
+    "zeroize?/std",
+]
 alloc = ["proptest?/alloc", "rand?/alloc", "serde?/alloc", "valuable?/alloc", "zeroize?/alloc"]
 
 # nightly-only features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ rlp = { version = "0.5", optional = true, default-features = false }
 serde = { version = "1", optional = true, default-features = false }
 valuable = { version = "0.1", optional = true, default-features = false }
 zeroize = { version = "1.6", optional = true, default-features = false }
+bytemuck = { version = "1.13.1", optional = true, default-features = false }
 
 # postgres
 bytes = { version = "1.4", optional = true }
@@ -69,7 +70,6 @@ postgres-types = { version = "0.2", optional = true }
 
 # sqlx
 sqlx-core = { version = "0.7", optional = true }
-bytemuck = "1.13.1"
 
 [dev-dependencies]
 ruint = { path = ".", features = ["arbitrary", "proptest"] }
@@ -116,6 +116,7 @@ rlp = ["dep:rlp", "alloc"]
 serde = ["dep:serde", "alloc"] # TODO: try to avoid alloc in serde impls
 valuable = ["dep:valuable"]
 zeroize = ["dep:zeroize"]
+bytemuck = ["dep:bytemuck"]
 
 postgres = ["dep:postgres-types", "dep:bytes", "std", "dep:thiserror"]
 sqlx = ["dep:sqlx-core", "std", "dep:thiserror"]

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ named feature flag.
 * [`pyo3`](https://docs.rs/pyo3): Implements the [`ToPyObject`](https://docs.rs/pyo3/latest/pyo3/conversion/trait.ToPyObject.html), [`IntoPy`](https://docs.rs/pyo3/latest/pyo3/conversion/trait.IntoPy.html) and [`FromPyObject`](https://docs.rs/pyo3/latest/pyo3/conversion/trait.FromPyObject.html) traits.
 * [`parity-scale-codec`](https://docs.rs/parity-scale-codec): Implements the [`Encode`](https://docs.rs/parity-scale-codec/latest/parity_scale_codec/trait.Encode.html), [`Decode`](https://docs.rs/parity-scale-codec/latest/parity_scale_codec/trait.Decode.html), [`MaxEncodedLen`](https://github.com/paritytech/parity-scale-codec/blob/47d98a1c23dabc890fdb548d115a18070082c66e/src/max_encoded_len.rs) and [`HasCompact`](https://docs.rs/parity-scale-codec/latest/parity_scale_codec/trait.HasCompact.html) traits.
 * [`bn-rs`](https://docs.rs/bn-rs/latest/bn_rs/): Implements conversion to/from the [`BN`](https://docs.rs/bn-rs/latest/bn_rs/struct.BN.html) and [`BigNumber`](https://docs.rs/bn-rs/latest/bn_rs/struct.BigNumber.html).
+* [`bytemuck`](https://docs.rs/bytemuck): Implements the [`Pod`](https://docs.rs/bytemuck/latest/bytemuck/trait.Pod.html) and [Zeroable](https://docs.rs/bytemuck/latest/bytemuck/trait.Zeroable.html) traits for [`Uint`] where the size is a multiple of 64, up to 1024. This allows `Uint` to be used where a `Pod` trait bound exists.
+
 
 ## Building and testing
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ named feature flag.
 * [`pyo3`](https://docs.rs/pyo3): Implements the [`ToPyObject`](https://docs.rs/pyo3/latest/pyo3/conversion/trait.ToPyObject.html), [`IntoPy`](https://docs.rs/pyo3/latest/pyo3/conversion/trait.IntoPy.html) and [`FromPyObject`](https://docs.rs/pyo3/latest/pyo3/conversion/trait.FromPyObject.html) traits.
 * [`parity-scale-codec`](https://docs.rs/parity-scale-codec): Implements the [`Encode`](https://docs.rs/parity-scale-codec/latest/parity_scale_codec/trait.Encode.html), [`Decode`](https://docs.rs/parity-scale-codec/latest/parity_scale_codec/trait.Decode.html), [`MaxEncodedLen`](https://github.com/paritytech/parity-scale-codec/blob/47d98a1c23dabc890fdb548d115a18070082c66e/src/max_encoded_len.rs) and [`HasCompact`](https://docs.rs/parity-scale-codec/latest/parity_scale_codec/trait.HasCompact.html) traits.
 * [`bn-rs`](https://docs.rs/bn-rs/latest/bn_rs/): Implements conversion to/from the [`BN`](https://docs.rs/bn-rs/latest/bn_rs/struct.BN.html) and [`BigNumber`](https://docs.rs/bn-rs/latest/bn_rs/struct.BigNumber.html).
-* [`bytemuck`](https://docs.rs/bytemuck): Implements the [`Pod`](https://docs.rs/bytemuck/latest/bytemuck/trait.Pod.html) and [Zeroable](https://docs.rs/bytemuck/latest/bytemuck/trait.Zeroable.html) traits for [`Uint`] where the size is a multiple of 64, up to 1024. This allows `Uint` to be used where a `Pod` trait bound exists.
+* [`bytemuck`](https://docs.rs/bytemuck): Implements the [`Pod`](https://docs.rs/bytemuck/latest/bytemuck/trait.Pod.html) and [`Zeroable`](https://docs.rs/bytemuck/latest/bytemuck/trait.Zeroable.html) traits for [`Uint`] where the size is a multiple of 64, up to 1024. This allows `Uint` to be used where a `Pod` trait bound exists.
 
 
 ## Building and testing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@ pub mod nightly {
 ///
 /// [std-overflow]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#overflow
 #[derive(Clone, Copy, Eq, PartialEq, Hash)]
+#[repr(transparent)]
 pub struct Uint<const BITS: usize, const LIMBS: usize> {
     limbs: [u64; LIMBS],
 }

--- a/src/support/bytemuck.rs
+++ b/src/support/bytemuck.rs
@@ -17,5 +17,45 @@ macro_rules! impl_pod {
 impl_pod! {
     64, 128, 192, 256, 320, 384, 448, 512, 576, 640, 704, 768, 832, 896, 960, 1024,
 }
+
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use bytemuck::{Pod, Zeroable};
+    use ruint::Uint;
+
+    #[test]
+    fn test_uint_pod() {
+        test_pod::<64, 1>();
+        test_pod::<128, 2>();
+        test_pod::<192, 3>();
+        test_pod::<256, 4>();
+        test_pod::<320, 5>();
+        test_pod::<384, 6>();
+        test_pod::<448, 7>();
+        test_pod::<512, 8>();
+        test_pod::<576, 9>();
+        test_pod::<640, 10>();
+        test_pod::<704, 11>();
+        test_pod::<768, 12>();
+        test_pod::<832, 13>();
+        test_pod::<896, 14>();
+        test_pod::<960, 15>();
+        test_pod::<1024, 16>();
+    }
+
+    fn test_pod<const BITS: usize, const LIMBS: usize>()
+    where
+        Uint<{ BITS }, { LIMBS }>: Zeroable + Pod + Eq + Default,
+    {
+        let val = Uint::<{ BITS }, { LIMBS }>::default();
+        let bytes = bytemuck::bytes_of(&val);
+
+        assert_eq!(
+            bytes.len(),
+            std::mem::size_of::<Uint<{ BITS }, { LIMBS }>>()
+        );
+
+        let zeroed_val: Uint<{ BITS }, { LIMBS }> = Zeroable::zeroed();
+        assert_eq!(zeroed_val, Uint::<{ BITS }, { LIMBS }>::default());
+    }
+}

--- a/src/support/bytemuck.rs
+++ b/src/support/bytemuck.rs
@@ -1,0 +1,21 @@
+use bytemuck::Pod;
+use ruint::Uint;
+
+macro_rules! impl_pod {
+    ($($bits:expr),+ $(,)?) => {
+        $(
+            unsafe impl<const LIMBS: usize> bytemuck::Zeroable for Uint<{$bits}, LIMBS> {}
+            unsafe impl<const LIMBS: usize> Pod for Uint<{$bits}, LIMBS> where
+                [(); {$bits % 64}]: ,
+                [(); LIMBS]: ,
+            {
+            }
+        )+
+    };
+}
+
+impl_pod! {
+    64, 128, 192, 256, 320, 384, 448, 512, 576, 640, 704, 768, 832, 896, 960, 1024,
+}
+#[cfg(test)]
+mod tests {}

--- a/src/support/bytemuck.rs
+++ b/src/support/bytemuck.rs
@@ -1,9 +1,11 @@
+//! Support for the [`bytemuck`](https://crates.io/crates/bytemuck) crate.
 #![cfg(feature = "bytemuck")]
 #![cfg_attr(docsrs, doc(cfg(feature = "bytemuck")))]
 
 use bytemuck::Pod;
 use ruint::Uint;
 
+// Implement the `Pod` trait for `Uint` types with a size that is a multiple of 64, up to 1024.
 macro_rules! impl_pod {
     ($($bits:expr),+ $(,)?) => {
         $(

--- a/src/support/bytemuck.rs
+++ b/src/support/bytemuck.rs
@@ -8,7 +8,10 @@ use ruint::Uint;
 // Implement Zeroable for all `Uint` types.
 unsafe impl<const BITS: usize, const LIMBS: usize> Zeroable for Uint<{ BITS }, { LIMBS }> {}
 
-// Implement the `Pod` trait for `Uint` types with a size that is a multiple of 64, up to 1024.
+// Implement the `Pod` trait for `Uint` types with a size that is a multiple of
+// 64, up to 1024. Note that implementors must have a size that is divisible by
+// 64, and using `Uint` sizes not divisible by 64 would violate Pod's
+// guarantees potentially leading to undefined behavior.
 macro_rules! impl_pod {
     ($(($bits:expr, $limbs:expr)),+ $(,)?) => {
         $(

--- a/src/support/bytemuck.rs
+++ b/src/support/bytemuck.rs
@@ -12,9 +12,7 @@ unsafe impl<const BITS: usize, const LIMBS: usize> Zeroable for Uint<{ BITS }, {
 macro_rules! impl_pod {
     ($(($bits:expr, $limbs:expr)),+ $(,)?) => {
         $(
-            unsafe impl Pod for Uint<{$bits}, $limbs> where
-            {
-            }
+            unsafe impl Pod for Uint<{$bits}, $limbs> {}
         )+
     };
 }

--- a/src/support/bytemuck.rs
+++ b/src/support/bytemuck.rs
@@ -1,3 +1,6 @@
+#![cfg(feature = "bytemuck")]
+#![cfg_attr(docsrs, doc(cfg(feature = "bytemuck")))]
+
 use bytemuck::Pod;
 use ruint::Uint;
 

--- a/src/support/bytemuck.rs
+++ b/src/support/bytemuck.rs
@@ -2,17 +2,17 @@
 #![cfg(feature = "bytemuck")]
 #![cfg_attr(docsrs, doc(cfg(feature = "bytemuck")))]
 
-use bytemuck::Pod;
+use bytemuck::{Pod, Zeroable};
 use ruint::Uint;
+
+// Implement Zeroable for all `Uint` types.
+unsafe impl<const BITS: usize, const LIMBS: usize> Zeroable for Uint<{ BITS }, { LIMBS }> {}
 
 // Implement the `Pod` trait for `Uint` types with a size that is a multiple of 64, up to 1024.
 macro_rules! impl_pod {
-    ($($bits:expr),+ $(,)?) => {
+    ($(($bits:expr, $limbs:expr)),+ $(,)?) => {
         $(
-            unsafe impl<const LIMBS: usize> bytemuck::Zeroable for Uint<{$bits}, LIMBS> {}
-            unsafe impl<const LIMBS: usize> Pod for Uint<{$bits}, LIMBS> where
-                [(); {$bits % 64}]: ,
-                [(); LIMBS]: ,
+            unsafe impl Pod for Uint<{$bits}, $limbs> where
             {
             }
         )+
@@ -20,7 +20,22 @@ macro_rules! impl_pod {
 }
 
 impl_pod! {
-    64, 128, 192, 256, 320, 384, 448, 512, 576, 640, 704, 768, 832, 896, 960, 1024,
+    (64, 1),
+    (128, 2),
+    (192, 3),
+    (256, 4),
+    (320, 5),
+    (384, 6),
+    (448, 7),
+    (512, 8),
+    (576, 9),
+    (640, 10),
+    (704, 11),
+    (768, 12),
+    (832, 13),
+    (896, 14),
+    (960, 15),
+    (1024, 16),
 }
 
 #[cfg(test)]

--- a/src/support/mod.rs
+++ b/src/support/mod.rs
@@ -5,6 +5,7 @@ mod arbitrary;
 mod ark_ff;
 mod ark_ff_04;
 mod bn_rs;
+mod bytemuck;
 mod fastrlp;
 mod num_bigint;
 pub mod postgres;


### PR DESCRIPTION
## Motivation

This PR implements the [`Pod` trait](https://docs.rs/bytemuck/latest/bytemuck/trait.Pod.html) on `Uint` types where the size is a multiple of 64, up to 1024. This allows `Uint` types within this range to be used in instances where a `Pod` trait bound exists.

## Solution

This implementation uses a simple macro to implement the `Pod` trait on the following Uint sizes listed below.

```rust

macro_rules! impl_pod {
    ($(($bits:expr, $limbs:expr)),+ $(,)?) => {
        $(
            unsafe impl Pod for Uint<{$bits}, $limbs> {}
        )+
    };
}


impl_pod! {
    (64, 1),
    (128, 2),
    (192, 3),
    (256, 4),
    (320, 5),
    (384, 6),
    (448, 7),
    (512, 8),
    (576, 9),
    (640, 10),
    (704, 11),
    (768, 12),
    (832, 13),
    (896, 14),
    (960, 15),
    (1024, 16),
}
```

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog

