### PR TITLE
fix invalid std primitive overflowing_shr link in docs

### DIFF
--- a/src/bits.rs
+++ b/src/bits.rs
@@ -352,7 +352,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// it was rounded down. This is the same as non-zero bits being shifted
     /// out.
     ///
-    /// Note: This differs from [`u64::overflowing_shl`] which returns `true` if
+    /// Note: This differs from [`u64::overflowing_shr`] which returns `true` if
     /// the shift is larger than `BITS` (which is IMHO not very useful).
     #[must_use]
     pub fn overflowing_shr(mut self, rhs: usize) -> (Self, bool) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

`overflowing_shr` documentation linked to `u64::overflowing_shl` instead of `u64::overflowing_shr`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
