### PR TITLE
[Placeholder] fix: restrict parity-scale-codec to <3.6.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ bn-rs = { version = "0.2", optional = true, default-features = true }
 fastrlp = { version = "0.3", optional = true, default-features = false, features = ["alloc"] }
 num-bigint = { version = "0.4", optional = true, default-features = false }
 num-traits = { version = "0.2.16", optional = true, default-features = false }
-parity-scale-codec = { version = "3", optional = true, features = [
+parity-scale-codec = { version = "3, <3.6.7", optional = true, features = [
     "derive",
     "max-encoded-len",
 ], default-features = false }


### PR DESCRIPTION
Workaround for https://github.com/paritytech/parity-scale-codec/issues/520

Don't merge unless upstream fix never appears

## Motivation

## Solution

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
