### PR TITLE
dep: pin anstyle to 1.65 compat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,10 +79,12 @@ ark-bn254-03 = { version = "0.3.0", package = "ark-bn254" }
 ark-bn254-04 = { version = "0.4.0", package = "ark-bn254" }
 
 criterion = "0.5"
-# clap and clap_lex, referred by criterion, have higher a MSRV (clap@4.4.0, clap_lex@0.5.1),
+# This crates are dependencies of criterion, with a higher MSRV
+# (clap@4.4.0, clap_lex@0.5.1, anstyle@1.0.3),
 # but are only used by dev-dependencies so we can just pin them
 clap = "~4.3"
 clap_lex = "<=0.5.0"
+anstyle = "<=1.0.2"
 
 rand = "0.8"
 


### PR DESCRIPTION

## Motivation

anstyle at 1.0.3 has a 1.70 MSRV


## Solution

Pin dep to compatible version

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
