### PR TITLE
fix scale support for upcoming versions

### DIFF
--- a/src/support/scale.rs
+++ b/src/support/scale.rs
@@ -81,7 +81,12 @@ impl<const BITS: usize, const LIMBS: usize> MaxEncodedLen for CompactUint<BITS, 
     }
 }
 
-impl<const BITS: usize, const LIMBS: usize> Encode for CompactUint<BITS, LIMBS> {}
+impl<const BITS: usize, const LIMBS: usize> Encode for CompactUint<BITS, LIMBS> {
+    fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+        let v: CompactRefUint<BITS, LIMBS> = (&self.0).into();
+        v.encode_to(dest)
+    }
+}
 
 impl<const BITS: usize, const LIMBS: usize> HasCompact for Uint<BITS, LIMBS> {
     type Type = CompactUint<BITS, LIMBS>;

--- a/src/support/scale.rs
+++ b/src/support/scale.rs
@@ -75,6 +75,14 @@ impl<const BITS: usize, const LIMBS: usize> CompactAs for CompactUint<BITS, LIMB
     }
 }
 
+impl<const BITS: usize, const LIMBS: usize> MaxEncodedLen for CompactUint<BITS, LIMBS> {
+    fn max_encoded_len() -> usize {
+        Uint::<BITS, LIMBS>::max_encoded_len()
+    }
+}
+
+impl<const BITS: usize, const LIMBS: usize> Encode for CompactUint<BITS, LIMBS> {}
+
 impl<const BITS: usize, const LIMBS: usize> HasCompact for Uint<BITS, LIMBS> {
     type Type = CompactUint<BITS, LIMBS>;
 }


### PR DESCRIPTION
This PR should fix breaking changes for upcoming parity-scale-codec versions

## Motivation

We have added some constraints to the HasCompact trait in https://github.com/paritytech/parity-scale-codec/pull/512
to fix MaxEncodedLen for compact fields.

```diff
/// Trait that tells you if a given type can be encoded/decoded in a compact way.
pub trait HasCompact: Sized {
	/// The compact type; this can be
-	type Type: for<'a> EncodeAsRef<'a, Self> + Decode + From<Self> + Into<Self>;
+	type Type: for<'a> EncodeAsRef<'a, Self> + Decode + From<Self> + Into<Self> + MaybeMaxEncodedLen;
}
```

This is so that we can fix the `MaxEncodedLen` derive trait for Compact field

```diff
- ty.span() => .saturating_add(<#crate_path::Compact::<#ty> as #crate_path::MaxEncodedLen>::max_encoded_len())
+ ty.span() => .saturating_add(<<#ty as #crate_path::HasCompact>::Type as #crate_path::MaxEncodedLen>::max_encoded_len())
```

This change breaks uint, thus this PR to attempt to fix it.

## Solution

This PR implements MaxEncodedLen for CompactUint (and Encode as required) to fix the compilation issue with upcoming versions

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
