### PR TITLE
perf: improve add and sub performance by avoiding `array::IntoIter`

### DIFF
--- a/src/add.rs
+++ b/src/add.rs
@@ -64,7 +64,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         }
         let mut carry = 0_u128;
         #[allow(clippy::cast_possible_truncation)] // Intentional
-        for (lhs, rhs) in self.limbs.iter_mut().zip(rhs.limbs) {
+        for (lhs, &rhs) in self.limbs.iter_mut().zip(rhs.as_limbs()) {
             carry += u128::from(*lhs) + u128::from(rhs);
             *lhs = carry as u64;
             carry >>= 64;
@@ -100,7 +100,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         let mut carry = 0_i128;
         #[allow(clippy::cast_possible_truncation)] // Intentional
         #[allow(clippy::cast_sign_loss)] // Intentional
-        for (lhs, rhs) in self.limbs.iter_mut().zip(rhs.limbs) {
+        for (lhs, &rhs) in self.limbs.iter_mut().zip(rhs.as_limbs()) {
             carry += i128::from(*lhs) - i128::from(rhs);
             *lhs = carry as u64;
             carry >>= 64; // Sign extending shift

--- a/src/base_convert.rs
+++ b/src/base_convert.rs
@@ -125,7 +125,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
             }
 
             // Add digit to result
-            let overflow = addmul_nx1(&mut result.limbs, &power.limbs, digit);
+            let overflow = addmul_nx1(&mut result.limbs, power.as_limbs(), digit);
             if overflow != 0 || result.limbs[LIMBS - 1] > Self::MASK {
                 return Err(BaseConvertError::Overflow);
             }

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -479,7 +479,7 @@ macro_rules! impl_bit_op {
             for Uint<BITS, LIMBS>
         {
             fn $fn_assign(&mut self, rhs: &Uint<BITS, LIMBS>) {
-                for (limb, rhs) in self.limbs.iter_mut().zip(rhs.limbs) {
+                for (limb, &rhs) in self.limbs.iter_mut().zip(rhs.as_limbs()) {
                     u64::$fn_assign(limb, rhs);
                 }
             }

--- a/src/modular.rs
+++ b/src/modular.rs
@@ -61,7 +61,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         // Alternatively we could use `alloca`, but that is blocked on
         // See <https://github.com/rust-lang/rust/issues/48055>
         let mut product = vec![0; crate::nlimbs(2 * BITS)];
-        let overflow = algorithms::addmul(&mut product, &self.limbs, &rhs.limbs);
+        let overflow = algorithms::addmul(&mut product, self.as_limbs(), rhs.as_limbs());
         debug_assert!(!overflow);
 
         // Compute modulus using `div_rem`.
@@ -152,10 +152,10 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         assert_eq!(inv.wrapping_mul(modulus.limbs[0]), u64::MAX);
         let mut result = Self::ZERO;
         algorithms::mul_redc(
-            &self.limbs,
-            &other.limbs,
+            self.as_limbs(),
+            other.as_limbs(),
             &mut result.limbs,
-            &modulus.limbs,
+            modulus.as_limbs(),
             inv,
         );
         debug_assert!(result < modulus);

--- a/src/mul.rs
+++ b/src/mul.rs
@@ -140,7 +140,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         assert_eq!(BITS_RES, BITS + BITS_RHS);
         assert_eq!(LIMBS_RES, nlimbs(BITS_RES));
         let mut result = Uint::<BITS_RES, LIMBS_RES>::ZERO;
-        algorithms::addmul(&mut result.limbs, &self.limbs, &rhs.limbs);
+        algorithms::addmul(&mut result.limbs, self.as_limbs(), rhs.as_limbs());
         if LIMBS_RES > 0 {
             debug_assert!(result.limbs[LIMBS_RES - 1] <= Uint::<BITS_RES, LIMBS_RES>::MASK);
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

`array::IntoIter` is known to have worse performance than `slice::Iter`.

## Solution

Use `slice::Iter` instead of `array::IntoIter`.

This makes codegen of `U256::add` identical to LLVM native `add i256`, while slightly improves the one in `sub`.

Rest of changes are `&(\w+)\.limbs` -> `$1.as_limbs()`.

Ideally we would deny inclusion of new `array::IntoIter` calls unless explicitly allowed, but I don't know how to do this since clippy does not catch it with `disallowed-methods`.

## Test

```rust
pub extern "C" fn u256_add(a: &mut aliases::U256, b: &aliases::U256) {
    *a += *b;
}

pub extern "C" fn u256_sub(a: &mut aliases::U256, b: &aliases::U256) {
    *a -= *b;
}
```

### `u256_add` before/after diff

<details>
<p>

```diff
diff --git a/add.before.s b/add.after.s
index 2970898..528fed6 100644
--- a/add.before.s
+++ b/add.after.s
@@ -4,25 +4,14 @@ u256_add:
 	mov rax, qword ptr [rsi]
 	mov rcx, qword ptr [rsi + 8]
 
-	add rax, qword ptr [rdi]
+	mov rdx, qword ptr [rsi + 16]
 
-	adc rcx, 0
-	setb dl
-	add rcx, qword ptr [rdi + 8]
+	mov rsi, qword ptr [rsi + 24]
 
-	movzx edx, dl
-	adc rdx, qword ptr [rsi + 16]
-	setb r8b
-	add rdx, qword ptr [rdi + 16]
-
-	mov qword ptr [rdi], rax
-	mov qword ptr [rdi + 8], rcx
-
-	movzx r8d, r8b
-	adc r8, qword ptr [rsi + 24]
-
-	mov qword ptr [rdi + 16], rdx
-	add qword ptr [rdi + 24], r8
+	add qword ptr [rdi], rax
+	adc qword ptr [rdi + 8], rcx
+	adc qword ptr [rdi + 16], rdx
+	adc qword ptr [rdi + 24], rsi
 
 	ret
```

</p>
</details>

### `u256_sub` before/after diff

<details>
<p>

```diff
diff --git a/sub.before.s b/sub.after.s
index bc0ce52..2a87c7a 100644
--- a/sub.before.s
+++ b/sub.after.s
@@ -1,47 +1,50 @@
 u256_sub:
 
 	.cfi_startproc
-	mov rdx, qword ptr [rdi + 24]
-
 	mov rcx, qword ptr [rdi + 16]
 
 	xor r8d, r8d
 
 	mov rax, qword ptr [rdi + 8]
 
+	mov rdx, qword ptr [rsi]
+
 	mov r9d, 0
+	mov r10d, 0
 
-	mov r10, qword ptr [rsi]
+	mov r11, qword ptr [rdi + 24]
 
-	sub rdx, qword ptr [rsi + 24]
 	sub rcx, qword ptr [rsi + 16]
 	sbb r9, r9
+
 	sub rax, qword ptr [rsi + 8]
-	mov esi, 0
+	sbb r10, r10
 
-	sbb rsi, rsi
+	sub r11, qword ptr [rsi + 24]
 
-	sub qword ptr [rdi], r10
+	sub qword ptr [rdi], rdx
 
 	sbb r8, r8
-	mov r10, r8
-	sar r10, 63
+
+	mov rdx, r8
+	sar rdx, 63
+
 	add r8, rax
 
-	adc r10, rsi
+	adc rdx, r10
 
 	mov qword ptr [rdi + 8], r8
 
-	mov rax, r10
+	mov rax, rdx
 	sar rax, 63
 
-	add r10, rcx
+	add rdx, rcx
 
 	adc rax, r9
 
-	mov qword ptr [rdi + 16], r10
+	mov qword ptr [rdi + 16], rdx
 
-	add rax, rdx
+	add rax, r11
 
 	mov qword ptr [rdi + 24], rax
```
</p>
</details>

### Optimal codegen

<details>
<p>

From Zig ([Godbolt](https://godbolt.org/z/6acWG3zPc)):

```zig
pub export fn u256_add(a: *u256, b: *u256) void {
    a.* += b.*;
}

pub export fn u256_sub(a: *u256, b: *u256) void {
    a.* -= b.*;
}
```

```asm
u256_add:
        mov     rax, qword ptr [rsi + 24]
        mov     rcx, qword ptr [rsi + 16]
        mov     rdx, qword ptr [rsi]
        mov     rsi, qword ptr [rsi + 8]
        add     qword ptr [rdi], rdx
        adc     qword ptr [rdi + 8], rsi
        adc     qword ptr [rdi + 16], rcx
        adc     qword ptr [rdi + 24], rax
        ret

u256_sub:
        mov     rax, qword ptr [rsi + 24]
        mov     rcx, qword ptr [rsi + 16]
        mov     rdx, qword ptr [rsi]
        mov     rsi, qword ptr [rsi + 8]
        sub     qword ptr [rdi], rdx
        sbb     qword ptr [rdi + 8], rsi
        sbb     qword ptr [rdi + 16], rcx
        sbb     qword ptr [rdi + 24], rax
        ret
```

</p>
</details>

### Actual codegen (after this PR)

<details>
<p>

```asm
u256_add:

	.cfi_startproc
	mov rax, qword ptr [rsi]
	mov rcx, qword ptr [rsi + 8]

	mov rdx, qword ptr [rsi + 16]

	mov rsi, qword ptr [rsi + 24]

	add qword ptr [rdi], rax
	adc qword ptr [rdi + 8], rcx
	adc qword ptr [rdi + 16], rdx
	adc qword ptr [rdi + 24], rsi

	ret

u256_sub:

	.cfi_startproc
	mov rcx, qword ptr [rdi + 16]

	xor r8d, r8d

	mov rax, qword ptr [rdi + 8]

	mov rdx, qword ptr [rsi]

	mov r9d, 0
	mov r10d, 0

	mov r11, qword ptr [rdi + 24]

	sub rcx, qword ptr [rsi + 16]
	sbb r9, r9

	sub rax, qword ptr [rsi + 8]
	sbb r10, r10

	sub r11, qword ptr [rsi + 24]

	sub qword ptr [rdi], rdx

	sbb r8, r8

	mov rdx, r8
	sar rdx, 63

	add r8, rax

	adc rdx, r10

	mov qword ptr [rdi + 8], r8

	mov rax, rdx
	sar rax, 63

	add rdx, rcx

	adc rax, r9

	mov qword ptr [rdi + 16], rdx

	add rax, r11

	mov qword ptr [rdi + 24], rax

	ret
```

</p>
</details>

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->