### PR TITLE
chore: remove unnecessary `#[allow(clippy::inline_always)]`

### DIFF
--- a/src/add.rs
+++ b/src/add.rs
@@ -8,7 +8,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// Computes the absolute difference between `self` and `other`.
     ///
     /// Returns $\left\vert \mathtt{self} - \mathtt{other} \right\vert$.
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn abs_diff(self, other: Self) -> Self {
@@ -20,7 +19,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     }
 
     /// Computes `self + rhs`, returning [`None`] if overflow occurred.
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn checked_add(self, rhs: Self) -> Option<Self> {
@@ -31,7 +29,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     }
 
     /// Computes `-self`, returning [`None`] unless `self == 0`.
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn checked_neg(self) -> Option<Self> {
@@ -42,7 +39,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     }
 
     /// Computes `self - rhs`, returning [`None`] if overflow occurred.
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn checked_sub(self, rhs: Self) -> Option<Self> {
@@ -80,7 +76,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// represents the negation of this unsigned value. Note that for positive
     /// unsigned values overflow always occurs, but negating 0 does not
     /// overflow.
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn overflowing_neg(self) -> (Self, bool) {
@@ -112,7 +107,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
 
     /// Computes `self + rhs`, saturating at the numeric bounds instead of
     /// overflowing.
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn saturating_add(self, rhs: Self) -> Self {
@@ -124,7 +118,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
 
     /// Computes `self - rhs`, saturating at the numeric bounds instead of
     /// overflowing
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn saturating_sub(self, rhs: Self) -> Self {
@@ -135,7 +128,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     }
 
     /// Computes `self + rhs`, wrapping around at the boundary of the type.
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn wrapping_add(self, rhs: Self) -> Self {
@@ -143,7 +135,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     }
 
     /// Computes `-self`, wrapping around at the boundary of the type.
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn wrapping_neg(self) -> Self {
@@ -151,7 +142,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     }
 
     /// Computes `self - rhs`, wrapping around at the boundary of the type.
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn wrapping_sub(self, rhs: Self) -> Self {
@@ -162,7 +152,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
 impl<const BITS: usize, const LIMBS: usize> Neg for Uint<BITS, LIMBS> {
     type Output = Self;
 
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     fn neg(self) -> Self::Output {
         self.wrapping_neg()
@@ -172,7 +161,6 @@ impl<const BITS: usize, const LIMBS: usize> Neg for Uint<BITS, LIMBS> {
 impl<const BITS: usize, const LIMBS: usize> Neg for &Uint<BITS, LIMBS> {
     type Output = Uint<BITS, LIMBS>;
 
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     fn neg(self) -> Self::Output {
         self.wrapping_neg()

--- a/src/bit_arr.rs
+++ b/src/bit_arr.rs
@@ -74,14 +74,12 @@ impl<const BITS: usize, const LIMBS: usize> Bits<BITS, LIMBS> {
 macro_rules! forward_attributes {
     ($fnname:ident, $item:item $(,must_use: true)?) => {
         #[doc = concat!("See [`Uint::", stringify!($fnname),"`] for documentation.")]
-        #[allow(clippy::inline_always)]
         #[inline(always)]
         #[must_use]
         $item
     };
     ($fnname:ident, $item:item,must_use: false) => {
         #[doc = concat!("See [`Uint::", stringify!($fnname),"`] for documentation.")]
-        #[allow(clippy::inline_always)]
         #[inline(always)]
         $item
     };
@@ -291,7 +289,6 @@ macro_rules! impl_bit_op {
         impl<const BITS: usize, const LIMBS: usize> $trait_assign<Bits<BITS, LIMBS>>
             for Bits<BITS, LIMBS>
         {
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             fn $fn_assign(&mut self, rhs: Bits<BITS, LIMBS>) {
                 self.0.$fn_assign(&rhs.0);
@@ -300,7 +297,6 @@ macro_rules! impl_bit_op {
         impl<const BITS: usize, const LIMBS: usize> $trait_assign<&Bits<BITS, LIMBS>>
             for Bits<BITS, LIMBS>
         {
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             fn $fn_assign(&mut self, rhs: &Bits<BITS, LIMBS>) {
                 self.0.$fn_assign(rhs.0);
@@ -311,7 +307,6 @@ macro_rules! impl_bit_op {
         {
             type Output = Bits<BITS, LIMBS>;
 
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             fn $fn(mut self, rhs: Bits<BITS, LIMBS>) -> Self::Output {
                 self.0.$fn_assign(rhs.0);
@@ -323,7 +318,6 @@ macro_rules! impl_bit_op {
         {
             type Output = Bits<BITS, LIMBS>;
 
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             fn $fn(mut self, rhs: &Bits<BITS, LIMBS>) -> Self::Output {
                 self.0.$fn_assign(rhs.0);
@@ -335,7 +329,6 @@ macro_rules! impl_bit_op {
         {
             type Output = Bits<BITS, LIMBS>;
 
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             fn $fn(self, mut rhs: Bits<BITS, LIMBS>) -> Self::Output {
                 rhs.0.$fn_assign(self.0);
@@ -347,7 +340,6 @@ macro_rules! impl_bit_op {
         {
             type Output = Bits<BITS, LIMBS>;
 
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             fn $fn(self, rhs: &Bits<BITS, LIMBS>) -> Self::Output {
                 self.0.clone().$fn(rhs.0).into()
@@ -363,7 +355,6 @@ impl_bit_op!(BitXor, bitxor, BitXorAssign, bitxor_assign);
 macro_rules! impl_shift {
     ($trait:ident, $fn:ident, $trait_assign:ident, $fn_assign:ident) => {
         impl<const BITS: usize, const LIMBS: usize> $trait_assign<usize> for Bits<BITS, LIMBS> {
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             fn $fn_assign(&mut self, rhs: usize) {
                 self.0.$fn_assign(rhs);
@@ -371,7 +362,6 @@ macro_rules! impl_shift {
         }
 
         impl<const BITS: usize, const LIMBS: usize> $trait_assign<&usize> for Bits<BITS, LIMBS> {
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             fn $fn_assign(&mut self, rhs: &usize) {
                 self.0.$fn_assign(rhs);
@@ -381,7 +371,6 @@ macro_rules! impl_shift {
         impl<const BITS: usize, const LIMBS: usize> $trait<usize> for Bits<BITS, LIMBS> {
             type Output = Self;
 
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             fn $fn(self, rhs: usize) -> Self {
                 self.0.$fn(rhs).into()
@@ -391,7 +380,6 @@ macro_rules! impl_shift {
         impl<const BITS: usize, const LIMBS: usize> $trait<usize> for &Bits<BITS, LIMBS> {
             type Output = Bits<BITS, LIMBS>;
 
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             fn $fn(self, rhs: usize) -> Self::Output {
                 self.0.$fn(rhs).into()
@@ -401,7 +389,6 @@ macro_rules! impl_shift {
         impl<const BITS: usize, const LIMBS: usize> $trait<&usize> for Bits<BITS, LIMBS> {
             type Output = Self;
 
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             fn $fn(self, rhs: &usize) -> Self {
                 self.0.$fn(rhs).into()
@@ -411,7 +398,6 @@ macro_rules! impl_shift {
         impl<const BITS: usize, const LIMBS: usize> $trait<&usize> for &Bits<BITS, LIMBS> {
             type Output = Bits<BITS, LIMBS>;
 
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             fn $fn(self, rhs: &usize) -> Self::Output {
                 self.0.$fn(rhs).into()

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -214,7 +214,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     ///
     /// Note: This differs from [`u64::checked_shl`] which returns `None` if the
     /// shift is larger than BITS (which is IMHO not very useful).
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn checked_shl(self, rhs: usize) -> Option<Self> {
@@ -229,7 +228,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// Returns $\mathtt{self} ⋅ 2^{\mathtt{rhs}}$ or [`Uint::MAX`] if the
     /// result would $≥ 2^{\mathtt{BITS}}$. That is, it returns
     /// [`Uint::MAX`] if the bits shifted out would be non-zero.
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn saturating_shl(self, rhs: usize) -> Self {
@@ -305,7 +303,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     ///
     /// Note: This differs from [`u64::wrapping_shl`] which first reduces `rhs`
     /// by `BITS` (which is IMHO not very useful).
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn wrapping_shl(self, rhs: usize) -> Self {
@@ -323,7 +320,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     ///
     /// Note: This differs from [`u64::checked_shr`] which returns `None` if the
     /// shift is larger than BITS (which is IMHO not very useful).
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn checked_shr(self, rhs: usize) -> Option<Self> {
@@ -396,7 +392,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     ///
     /// Note: This differs from [`u64::wrapping_shr`] which first reduces `rhs`
     /// by `BITS` (which is IMHO not very useful).
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn wrapping_shr(self, rhs: usize) -> Self {
@@ -429,7 +424,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         self << rhs | self >> (BITS - rhs)
     }
 
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn rotate_right(self, rhs: usize) -> Self {
@@ -469,7 +463,6 @@ macro_rules! impl_bit_op {
         impl<const BITS: usize, const LIMBS: usize> $trait_assign<Uint<BITS, LIMBS>>
             for Uint<BITS, LIMBS>
         {
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             fn $fn_assign(&mut self, rhs: Uint<BITS, LIMBS>) {
                 self.$fn_assign(&rhs);
@@ -489,7 +482,6 @@ macro_rules! impl_bit_op {
         {
             type Output = Uint<BITS, LIMBS>;
 
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             fn $fn(mut self, rhs: Uint<BITS, LIMBS>) -> Self::Output {
                 self.$fn_assign(rhs);
@@ -501,7 +493,6 @@ macro_rules! impl_bit_op {
         {
             type Output = Uint<BITS, LIMBS>;
 
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             fn $fn(mut self, rhs: &Uint<BITS, LIMBS>) -> Self::Output {
                 self.$fn_assign(rhs);
@@ -513,7 +504,6 @@ macro_rules! impl_bit_op {
         {
             type Output = Uint<BITS, LIMBS>;
 
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             fn $fn(self, mut rhs: Uint<BITS, LIMBS>) -> Self::Output {
                 rhs.$fn_assign(self);
@@ -525,7 +515,6 @@ macro_rules! impl_bit_op {
         {
             type Output = Uint<BITS, LIMBS>;
 
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             fn $fn(self, rhs: &Uint<BITS, LIMBS>) -> Self::Output {
                 self.clone().$fn(rhs)
@@ -539,7 +528,6 @@ impl_bit_op!(BitAnd, bitand, BitAndAssign, bitand_assign);
 impl_bit_op!(BitXor, bitxor, BitXorAssign, bitxor_assign);
 
 impl<const BITS: usize, const LIMBS: usize> ShlAssign<usize> for Uint<BITS, LIMBS> {
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     fn shl_assign(&mut self, rhs: usize) {
         *self = self.wrapping_shl(rhs);
@@ -547,7 +535,6 @@ impl<const BITS: usize, const LIMBS: usize> ShlAssign<usize> for Uint<BITS, LIMB
 }
 
 impl<const BITS: usize, const LIMBS: usize> ShlAssign<&usize> for Uint<BITS, LIMBS> {
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     fn shl_assign(&mut self, rhs: &usize) {
         *self = self.wrapping_shl(*rhs);
@@ -557,7 +544,6 @@ impl<const BITS: usize, const LIMBS: usize> ShlAssign<&usize> for Uint<BITS, LIM
 impl<const BITS: usize, const LIMBS: usize> Shl<usize> for Uint<BITS, LIMBS> {
     type Output = Self;
 
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     fn shl(self, rhs: usize) -> Self {
         self.wrapping_shl(rhs)
@@ -567,7 +553,6 @@ impl<const BITS: usize, const LIMBS: usize> Shl<usize> for Uint<BITS, LIMBS> {
 impl<const BITS: usize, const LIMBS: usize> Shl<usize> for &Uint<BITS, LIMBS> {
     type Output = Uint<BITS, LIMBS>;
 
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     fn shl(self, rhs: usize) -> Self::Output {
         self.wrapping_shl(rhs)
@@ -577,7 +562,6 @@ impl<const BITS: usize, const LIMBS: usize> Shl<usize> for &Uint<BITS, LIMBS> {
 impl<const BITS: usize, const LIMBS: usize> Shl<&usize> for Uint<BITS, LIMBS> {
     type Output = Self;
 
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     fn shl(self, rhs: &usize) -> Self {
         self.wrapping_shl(*rhs)
@@ -587,7 +571,6 @@ impl<const BITS: usize, const LIMBS: usize> Shl<&usize> for Uint<BITS, LIMBS> {
 impl<const BITS: usize, const LIMBS: usize> Shl<&usize> for &Uint<BITS, LIMBS> {
     type Output = Uint<BITS, LIMBS>;
 
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     fn shl(self, rhs: &usize) -> Self::Output {
         self.wrapping_shl(*rhs)
@@ -595,7 +578,6 @@ impl<const BITS: usize, const LIMBS: usize> Shl<&usize> for &Uint<BITS, LIMBS> {
 }
 
 impl<const BITS: usize, const LIMBS: usize> ShrAssign<usize> for Uint<BITS, LIMBS> {
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     fn shr_assign(&mut self, rhs: usize) {
         *self = self.wrapping_shr(rhs);
@@ -603,7 +585,6 @@ impl<const BITS: usize, const LIMBS: usize> ShrAssign<usize> for Uint<BITS, LIMB
 }
 
 impl<const BITS: usize, const LIMBS: usize> ShrAssign<&usize> for Uint<BITS, LIMBS> {
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     fn shr_assign(&mut self, rhs: &usize) {
         *self = self.wrapping_shr(*rhs);
@@ -613,7 +594,6 @@ impl<const BITS: usize, const LIMBS: usize> ShrAssign<&usize> for Uint<BITS, LIM
 impl<const BITS: usize, const LIMBS: usize> Shr<usize> for Uint<BITS, LIMBS> {
     type Output = Self;
 
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     fn shr(self, rhs: usize) -> Self {
         self.wrapping_shr(rhs)
@@ -623,7 +603,6 @@ impl<const BITS: usize, const LIMBS: usize> Shr<usize> for Uint<BITS, LIMBS> {
 impl<const BITS: usize, const LIMBS: usize> Shr<usize> for &Uint<BITS, LIMBS> {
     type Output = Uint<BITS, LIMBS>;
 
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     fn shr(self, rhs: usize) -> Self::Output {
         self.wrapping_shr(rhs)
@@ -633,7 +612,6 @@ impl<const BITS: usize, const LIMBS: usize> Shr<usize> for &Uint<BITS, LIMBS> {
 impl<const BITS: usize, const LIMBS: usize> Shr<&usize> for Uint<BITS, LIMBS> {
     type Output = Self;
 
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     fn shr(self, rhs: &usize) -> Self {
         self.wrapping_shr(*rhs)
@@ -643,7 +621,6 @@ impl<const BITS: usize, const LIMBS: usize> Shr<&usize> for Uint<BITS, LIMBS> {
 impl<const BITS: usize, const LIMBS: usize> Shr<&usize> for &Uint<BITS, LIMBS> {
     type Output = Uint<BITS, LIMBS>;
 
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     fn shr(self, rhs: &usize) -> Self::Output {
         self.wrapping_shr(*rhs)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -3,7 +3,6 @@ macro_rules! impl_bin_op {
         impl<const BITS: usize, const LIMBS: usize> $trait_assign<Uint<BITS, LIMBS>>
             for Uint<BITS, LIMBS>
         {
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             #[track_caller]
             fn $fn_assign(&mut self, rhs: Uint<BITS, LIMBS>) {
@@ -13,7 +12,6 @@ macro_rules! impl_bin_op {
         impl<const BITS: usize, const LIMBS: usize> $trait_assign<&Uint<BITS, LIMBS>>
             for Uint<BITS, LIMBS>
         {
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             #[track_caller]
             fn $fn_assign(&mut self, rhs: &Uint<BITS, LIMBS>) {
@@ -25,7 +23,6 @@ macro_rules! impl_bin_op {
         {
             type Output = Uint<BITS, LIMBS>;
 
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             #[track_caller]
             fn $fn(self, rhs: Uint<BITS, LIMBS>) -> Self::Output {
@@ -37,7 +34,6 @@ macro_rules! impl_bin_op {
         {
             type Output = Uint<BITS, LIMBS>;
 
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             #[track_caller]
             fn $fn(self, rhs: &Uint<BITS, LIMBS>) -> Self::Output {
@@ -49,7 +45,6 @@ macro_rules! impl_bin_op {
         {
             type Output = Uint<BITS, LIMBS>;
 
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             #[track_caller]
             fn $fn(self, rhs: Uint<BITS, LIMBS>) -> Self::Output {
@@ -61,7 +56,6 @@ macro_rules! impl_bin_op {
         {
             type Output = Uint<BITS, LIMBS>;
 
-            #[allow(clippy::inline_always)]
             #[inline(always)]
             #[track_caller]
             fn $fn(self, rhs: &Uint<BITS, LIMBS>) -> Self::Output {

--- a/src/mul.rs
+++ b/src/mul.rs
@@ -7,7 +7,6 @@ use core::{
 
 impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// Computes `self * rhs`, returning [`None`] if overflow occurred.
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn checked_mul(self, rhs: Self) -> Option<Self> {
@@ -48,7 +47,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
 
     /// Computes `self * rhs`, saturating at the numeric bounds instead of
     /// overflowing.
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn saturating_mul(self, rhs: Self) -> Self {
@@ -59,7 +57,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     }
 
     /// Computes `self * rhs`, wrapping around at the boundary of the type.
-    #[allow(clippy::inline_always)]
     #[inline(always)]
     #[must_use]
     pub fn wrapping_mul(self, rhs: Self) -> Self {


### PR DESCRIPTION
It's allowed at the crate scope.