### PR TITLE
feat: make add and sub const fns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `bytemuck` feature ([#292])
 - `Uint::is_zero() -> bool` ([#296])
 - `num-traits` features ([#298])
+- Improve `add` and `sub` performance ([#316])
+- Make `add` and `sub` functions `const` ([#324])
 
 [#292]: https://github.com/recmo/uint/pulls/292
 [#298]: https://github.com/recmo/uint/pulls/298
+[#316]: https://github.com/recmo/uint/pulls/316
+[#324]: https://github.com/recmo/uint/pulls/324
 
 ### Fixed
 

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -16,7 +16,7 @@ impl<const BITS: usize, const LIMBS: usize> PartialOrd for Uint<BITS, LIMBS> {
 }
 
 impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
-    /// Check if this uint is zero
+    /// Returns true if the value is zero.
     #[inline]
     #[must_use]
     pub fn is_zero(&self) -> bool {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

By changing `for` with `while` we can make mark `add` and `sub` functions as `const`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
