### PR TITLE
fix: disallow leading zeros in RLP decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `leading_ones` failed for non-aligned sizes.
+- Restricted RLP decoding to match the RLP spec and disallow leading zeros ([#335])
+
+[#335]: https://github.com/recmo/uint/pulls/335
 
 ## [1.10.1] - 2023-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Restricted RLP decoding to match the RLP spec and disallow leading zeros ([#335])
+
+[#335]: https://github.com/recmo/uint/pulls/335
+
 ## [1.11.0] - 2023-10-27
 
 ### Added
@@ -32,9 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `leading_ones` failed for non-aligned sizes.
-- Restricted RLP decoding to match the RLP spec and disallow leading zeros ([#335])
-
-[#335]: https://github.com/recmo/uint/pulls/335
 
 ## [1.10.1] - 2023-07-30
 

--- a/src/support/alloy_rlp.rs
+++ b/src/support/alloy_rlp.rs
@@ -13,7 +13,7 @@ const MAX_BITS: usize = 55 * 8;
 
 /// Allows a [`Uint`] to be serialized as RLP.
 ///
-/// See <https://eth.wiki/en/fundamentals/rlp>
+/// See <https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/>
 impl<const BITS: usize, const LIMBS: usize> Encodable for Uint<BITS, LIMBS> {
     #[inline]
     fn length(&self) -> usize {
@@ -72,13 +72,19 @@ impl<const BITS: usize, const LIMBS: usize> Encodable for Uint<BITS, LIMBS> {
 
 /// Allows a [`Uint`] to be deserialized from RLP.
 ///
-/// See <https://eth.wiki/en/fundamentals/rlp>
+/// See <https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/>
 impl<const BITS: usize, const LIMBS: usize> Decodable for Uint<BITS, LIMBS> {
     #[inline]
     fn decode(buf: &mut &[u8]) -> Result<Self, Error> {
         let bytes = Header::decode_bytes(buf, false)?;
 
-        // We only need to check if the first byte is zero to make sure there are no
+        // The RLP spec states that deserialized positive integers with leading zeroes get treated
+        // as invalid.
+        //
+        // See:
+        // https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/
+        //
+        // To check this, we only need to check if the first byte is zero to make sure there are no
         // leading zeros
         if !bytes.is_empty() && bytes[0] == 0 {
             return Err(Error::LeadingZero);

--- a/src/support/alloy_rlp.rs
+++ b/src/support/alloy_rlp.rs
@@ -77,6 +77,7 @@ impl<const BITS: usize, const LIMBS: usize> Decodable for Uint<BITS, LIMBS> {
     #[inline]
     fn decode(buf: &mut &[u8]) -> Result<Self, Error> {
         let bytes = Header::decode_bytes(buf, false)?;
+        // TODO: leading zero and canonical representation checks
         Self::try_from_be_slice(bytes).ok_or(Error::Overflow)
     }
 }

--- a/src/support/alloy_rlp.rs
+++ b/src/support/alloy_rlp.rs
@@ -148,4 +148,24 @@ mod test {
             });
         });
     }
+
+    #[test]
+    fn test_invalid_uints() {
+        // these are non-canonical because they have leading zeros
+        assert_eq!(
+            U256::decode(&mut &hex!("820000")[..]),
+            Err(Error::LeadingZero)
+        );
+        assert_eq!(
+            U256::decode(&mut &hex!("8100")[..]),
+            Err(Error::LeadingZero)
+        );
+        // 00 is not a valid uint
+        // See https://github.com/ethereum/go-ethereum/blob/cd2953567268777507b1ec29269315324fb5aa9c/rlp/decode_test.go#L118
+        assert_eq!(U256::decode(&mut &hex!("00")[..]), Err(Error::LeadingZero));
+        // these are non-canonical because they can fit in a single byte, i.e.
+        // 0x7f, 0x assert_eq!(U256::decode(&mut &hex!("817f")[..]),
+        // Err(Error::LeadingZero)); assert_eq!(U256::decode(&mut
+        // &hex!("8133")[..]), Err(Error::LeadingZero));
+    }
 }

--- a/src/support/alloy_rlp.rs
+++ b/src/support/alloy_rlp.rs
@@ -78,14 +78,14 @@ impl<const BITS: usize, const LIMBS: usize> Decodable for Uint<BITS, LIMBS> {
     fn decode(buf: &mut &[u8]) -> Result<Self, Error> {
         let bytes = Header::decode_bytes(buf, false)?;
 
-        // The RLP spec states that deserialized positive integers with leading zeroes get treated
-        // as invalid.
+        // The RLP spec states that deserialized positive integers with leading zeroes
+        // get treated as invalid.
         //
         // See:
         // https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/
         //
-        // To check this, we only need to check if the first byte is zero to make sure there are no
-        // leading zeros
+        // To check this, we only need to check if the first byte is zero to make sure
+        // there are no leading zeros
         if !bytes.is_empty() && bytes[0] == 0 {
             return Err(Error::LeadingZero);
         }

--- a/src/support/fastrlp.rs
+++ b/src/support/fastrlp.rs
@@ -76,7 +76,14 @@ impl<const BITS: usize, const LIMBS: usize> Encodable for Uint<BITS, LIMBS> {
 impl<const BITS: usize, const LIMBS: usize> Decodable for Uint<BITS, LIMBS> {
     #[inline]
     fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
-        let bytes = Header::decode_bytes(buf, false)?;
+        // let bytes = Header::decode_bytes(buf, false)?;
+        let header = Header::decode(buf)?;
+        if header.list {
+            return Err(DecodeError::UnexpectedList);
+        }
+
+        let bytes = &buf[..header.payload_length];
+        *buf = &buf[header.payload_length..];
 
         // The RLP spec states that deserialized positive integers with leading zeroes
         // get treated as invalid.

--- a/src/support/fastrlp.rs
+++ b/src/support/fastrlp.rs
@@ -13,7 +13,7 @@ const MAX_BITS: usize = 55 * 8;
 
 /// Allows a [`Uint`] to be serialized as RLP.
 ///
-/// See <https://eth.wiki/en/fundamentals/rlp>
+/// See <https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/>
 impl<const BITS: usize, const LIMBS: usize> Encodable for Uint<BITS, LIMBS> {
     #[inline]
     fn length(&self) -> usize {
@@ -72,16 +72,24 @@ impl<const BITS: usize, const LIMBS: usize> Encodable for Uint<BITS, LIMBS> {
 
 /// Allows a [`Uint`] to be deserialized from RLP.
 ///
-/// See <https://eth.wiki/en/fundamentals/rlp>
+/// See <https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/>
 impl<const BITS: usize, const LIMBS: usize> Decodable for Uint<BITS, LIMBS> {
     #[inline]
     fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
-        let header = Header::decode(buf)?;
-        if header.list {
-            return Err(DecodeError::UnexpectedList);
+        let bytes = Header::decode_bytes(buf, false)?;
+
+        // The RLP spec states that deserialized positive integers with leading zeroes
+        // get treated as invalid.
+        //
+        // See:
+        // https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/
+        //
+        // To check this, we only need to check if the first byte is zero to make sure
+        // there are no leading zeros
+        if !bytes.is_empty() && bytes[0] == 0 {
+            return Err(Error::LeadingZero);
         }
-        let bytes = &buf[..header.payload_length];
-        *buf = &buf[header.payload_length..];
+
         Self::try_from_be_slice(bytes).ok_or(DecodeError::Overflow)
     }
 }

--- a/src/support/fastrlp.rs
+++ b/src/support/fastrlp.rs
@@ -87,7 +87,7 @@ impl<const BITS: usize, const LIMBS: usize> Decodable for Uint<BITS, LIMBS> {
         // To check this, we only need to check if the first byte is zero to make sure
         // there are no leading zeros
         if !bytes.is_empty() && bytes[0] == 0 {
-            return Err(Error::LeadingZero);
+            return Err(DecodeError::LeadingZero);
         }
 
         Self::try_from_be_slice(bytes).ok_or(DecodeError::Overflow)


### PR DESCRIPTION
## Motivation

Currently `Uint` RLP decoding ignores leading zeros.

## Solution

Disallow leading zeros.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [x] Updated the changelog
