### PR TITLE
Add non-allocating mul_mod

### DIFF
--- a/src/modular.rs
+++ b/src/modular.rs
@@ -74,6 +74,28 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         modulus
     }
 
+    /// Alloc free variant of [`mul_mod`](Self::mul_mod).
+    ///
+    /// Requires `N` to be set to `nlimbs(2 * BITS)`.
+    #[inline]
+    #[must_use]
+    pub fn mul_mod_na<const N: usize>(self, rhs: Self, mut modulus: Self) -> Self {
+        assert_eq!(N, crate::nlimbs(2 * BITS));
+        if modulus == Self::ZERO {
+            return Self::ZERO;
+        }
+        // Compute full product.
+        let mut product = [0; N];
+        let overflow = algorithms::addmul(&mut product, self.as_limbs(), rhs.as_limbs());
+        debug_assert!(!overflow);
+
+        // Compute modulus using `div_rem`.
+        // This stores the remainder in the divisor, `modulus`.
+        algorithms::div(&mut product, &mut modulus.limbs);
+
+        modulus
+    }
+
     /// Compute $\mod{\mathtt{self}^{\mathtt{rhs}}}_{\mathtt{modulus}}$.
     ///
     /// Returns zero if the modulus is zero.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The `Vec` allocation for intermediate result adds a lot of overhead to `mul_mod`.

## Solution

Unfortunately no good solutions, but in the new variant the caller can provide
a compile time hint.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
