### PR TITLE
fix: modify `overflowing_shr` to fix overflow check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Overflow check in `overflowing_shr` implementation ([#347])
+
+[#347]: https://github.com/recmo/uint/pulls/347
+
 ## [1.11.1] - 2023-11-18
 
 ### Fixed
@@ -16,10 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Typo in `Shr` implementation ([#343])
 
 [#343]: https://github.com/recmo/uint/pulls/343
-
-- Overflow check in `overflowing_shr` implementation
-
-[#347]: https://github.com/recmo/uint/pulls/347
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#343]: https://github.com/recmo/uint/pulls/343
 
+- Overflow check in `overflowing_shr` implementation
+
+[#347]: https://github.com/recmo/uint/pulls/347
+
 ### Added
 
 -   Enable `SSZ` ([#344])

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -854,18 +854,30 @@ mod tests {
 
     #[test]
     fn test_overflowing_shr() {
+        // Test: Single limb right shift from 40u64 by 1 bit.
+        // Expects resulting integer: 20 with no fractional part.
         assert_eq!(
             Uint::<64, 1>::from_limbs([40u64]).overflowing_shr(1),
             (Uint::<64, 1>::from(20), false)
         );
+
+        // Test: Single limb right shift from 41u64 by 1 bit.
+        // Expects resulting integer: 20 with a detected fractional part.
         assert_eq!(
             Uint::<64, 1>::from_limbs([41u64]).overflowing_shr(1),
             (Uint::<64, 1>::from(20), true)
         );
+
+        // Test: Two limbs right shift from 0x0010_0000_0000_0000 and 0 by 1 bit.
+        // Expects resulting limbs: [0x0080_0000_0000_000, 0] with no fractional part.
         assert_eq!(
             Uint::<65, 2>::from_limbs([0x0010_0000_0000_0000, 0]).overflowing_shr(1),
             (Uint::<65, 2>::from_limbs([0x0080_0000_0000_000, 0]), false)
         );
+
+        // Test: Shift beyond single limb capacity with MAX value.
+        // Expects the highest possible value in 256-bit representation with a detected
+        // fractional part.
         assert_eq!(
             Uint::<256, 4>::MAX.overflowing_shr(65),
             (
@@ -877,6 +889,8 @@ mod tests {
                 true
             )
         );
+        // Test: Large 4096-bit integer right shift by 34 bits.
+        // Expects a specific value with no fractional part.
         assert_eq!(
             Uint::<4096, 64>::from_str_radix("3ffffffffffffffffffffffffffffc00000000", 16,)
                 .unwrap()
@@ -886,6 +900,8 @@ mod tests {
                 false
             )
         );
+        // Test: Extremely large 4096-bit integer right shift by 100 bits.
+        // Expects a specific value with no fractional part.
         assert_eq!(
             Uint::<4096, 64>::from_str_radix(
                 "fffffffffffffffffffffffffffff0000000000000000000000000",
@@ -898,6 +914,8 @@ mod tests {
                 false
             )
         );
+        // Test: Complex 4096-bit integer right shift by 1 bit.
+        // Expects a specific value with no fractional part.
         assert_eq!(
             Uint::<4096, 64>::from_str_radix(
                 "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0bdbfe",
@@ -914,6 +932,8 @@ mod tests {
                 false
             )
         );
+        // Test: Large 4096-bit integer right shift by 1000 bits.
+        // Expects a specific value with no fractional part.
         assert_eq!(
             Uint::<4096, 64>::from_str_radix(
                 "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
@@ -930,6 +950,8 @@ mod tests {
                 false
             )
         );
+        // Test: MAX 4096-bit integer right shift by 34 bits.
+        // Expects a specific value with a detected fractional part.
         assert_eq!(
             Uint::<4096, 64>::MAX
             .overflowing_shr(34),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

`overflowing_shr` algorithm seems to give incorrect overflow results: #337.

Should close #337.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Added code to evaluate overflow for shift operation.
- This addition enables the identification of a floating-point outcome by isolating the most significant bit of the shifted limb.
- If the least significant bit of the shifted limb is non-zero, `overflow` is set to `true`, indicating a floating-point result.
- Enhances the functionality of the `overflowing_shr` function to differentiate between floating-point and integer outcomes after the shift operation.

This enhancement improves the functionality of the `overflowing_shr` method, providing a mechanism to determine whether the result represents a floating-point or integer value.

## PR Checklist

- [X] Added Tests
- [X] Added Documentation
- [X] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
