### PR TITLE
feat: wrap the `uint!` macro to allow usage without needing `uint` import

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "ruint"
 description = "Unsigned integer type with const-generic bit length"
-version = "1.11.1"
+version = "1.12.0"
 keywords = ["uint"]
 categories = ["mathematics"]
-exclude = ["benches/", "proptest-regressions/", "tests/"]
+include = ["src/**/*.rs", "README.md", "ruint-macro/README.md"]
 readme = "README.md"
 
 edition.workspace = true
@@ -37,7 +37,7 @@ path = "benches/bench.rs"
 required-features = ["std"]
 
 [dependencies]
-ruint-macro = { version = "1.1.0", path = "ruint-macro" }
+ruint-macro = { version = "1.2.0", path = "ruint-macro" }
 
 thiserror = { version = "1.0", optional = true }
 
@@ -108,7 +108,7 @@ std = [
     "rlp?/std",
     "serde?/std",
     "valuable?/std",
-    "zeroize?/std"
+    "zeroize?/std",
 ]
 ssz = ["std", "dep:ethereum_ssz"]
 alloc = ["proptest?/alloc", "rand?/alloc", "serde?/alloc", "valuable?/alloc", "zeroize?/alloc"]

--- a/ruint-macro/Cargo.toml
+++ b/ruint-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruint-macro"
-description = "The `uint!` macro for `Uint` literals"
-version = "1.1.0"
+description = "The `uint!` macro for `Uint` and `Bits` literals"
+version = "1.2.0"
 keywords = ["uint", "macro"]
 categories = ["mathematics"]
 readme = "README.md"

--- a/ruint-macro/README.md
+++ b/ruint-macro/README.md
@@ -63,7 +63,6 @@ error: Value too large for Uint<8>: 300
   |              ^^^^^^
 ```
 
-
 ## References
 
 * Rust [integer literals syntax](https://doc.rust-lang.org/stable/reference/tokens.html#integer-literals).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,10 +31,6 @@
     allow(incomplete_features)
 )]
 
-// Workaround for proc-macro `uint!` in this crate.
-// See <https://github.com/rust-lang/rust/pull/55275>
-extern crate self as ruint;
-
 #[cfg(feature = "alloc")]
 #[macro_use]
 extern crate alloc;
@@ -75,9 +71,6 @@ pub use self::{
     from::{FromUintError, ToFieldError, ToUintError, UintTryFrom, UintTryTo},
     string::ParseError,
 };
-
-#[doc(inline)]
-pub use ruint_macro::uint;
 
 #[cfg(feature = "generic_const_exprs")]
 pub mod nightly {
@@ -329,6 +322,12 @@ pub const fn mask(bits: usize) -> u64 {
     } else {
         (1 << bits) - 1
     }
+}
+
+// Not public API.
+#[doc(hidden)]
+pub mod __private {
+    pub use ruint_macro;
 }
 
 #[cfg(test)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,12 @@
+#[allow(rustdoc::broken_intra_doc_links)]
+#[doc = include_str!("../ruint-macro/README.md")]
+#[macro_export]
+macro_rules! uint {
+    ($($t:tt)*) => {
+        $crate::__private::ruint_macro::uint_with_path!([$crate] $($t)*)
+    }
+}
+
 macro_rules! impl_bin_op {
     ($trait:ident, $fn:ident, $trait_assign:ident, $fn_assign:ident, $fdel:ident) => {
         impl<const BITS: usize, const LIMBS: usize> $trait_assign<Uint<BITS, LIMBS>>
@@ -63,4 +72,21 @@ macro_rules! impl_bin_op {
             }
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_uint_macro_with_paths() {
+        extern crate self as aaa;
+        use crate as ruint;
+        use crate as __ruint;
+        let value = crate::aliases::U256::from(0x10);
+        assert_eq!(value, uint!(0x10U256));
+        assert_eq!(value, ruint_macro::uint_with_path!([crate] 0x10U256));
+        assert_eq!(value, ruint_macro::uint_with_path!([aaa] 0x10U256));
+        assert_eq!(value, ruint_macro::uint_with_path!([aaa] 0x10U256));
+        assert_eq!(value, ruint_macro::uint_with_path!([ruint] 0x10U256));
+        assert_eq!(value, ruint_macro::uint_with_path!([__ruint] 0x10U256));
+    }
 }

--- a/src/support/bytemuck.rs
+++ b/src/support/bytemuck.rs
@@ -2,8 +2,8 @@
 #![cfg(feature = "bytemuck")]
 #![cfg_attr(docsrs, doc(cfg(feature = "bytemuck")))]
 
+use crate::Uint;
 use bytemuck::{Pod, Zeroable};
-use ruint::Uint;
 
 // Implement Zeroable for all `Uint` types.
 unsafe impl<const BITS: usize, const LIMBS: usize> Zeroable for Uint<{ BITS }, { LIMBS }> {}

--- a/src/support/serde.rs
+++ b/src/support/serde.rs
@@ -204,7 +204,7 @@ mod tests {
             "0b1"
         ]"#;
         let numbers: Vec<Uint<1, 1>> = serde_json::from_str(jason).unwrap();
-        ruint_macro::uint! {
+        uint! {
             assert_eq!(numbers, vec![1_U1, 1_U1, 1_U1, 1_U1]);
         }
 
@@ -215,7 +215,7 @@ mod tests {
             "0b"
         ]"#;
         let numbers: Vec<Uint<1, 1>> = serde_json::from_str(jason).unwrap();
-        ruint_macro::uint! {
+        uint! {
             assert_eq!(numbers, vec![0_U1, 0_U1, 0_U1, 0_U1]);
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

Closes https://github.com/recmo/uint/issues/307

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
