### PR TITLE
fix num-traits with no-std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- add `alloc` requirement to `num-traits` feature  [#363]
+
+[#363]: https://github.com/recmo/uint/pull/363
+
 ## [1.12.1] - 2024-03-12
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruint"
 description = "Unsigned integer type with const-generic bit length"
-version = "1.12.1"
+version = "1.12.2"
 keywords = ["uint"]
 categories = ["mathematics"]
 include = [".cargo/", "src/", "README.md"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ ark-ff-04 = ["dep:ark-ff-04"]
 bn-rs = ["dep:bn-rs", "std"]
 fastrlp = ["dep:fastrlp", "alloc"]
 num-bigint = ["dep:num-bigint", "alloc"]
+num-traits = ["dep:num-traits", "alloc"]
 parity-scale-codec = ["dep:parity-scale-codec", "alloc"]
 primitive-types = ["dep:primitive-types"]
 proptest = ["dep:proptest", "std"] # TODO: change to "alloc" on the next proptest release (>1.2.0)

--- a/src/support/num_traits.rs
+++ b/src/support/num_traits.rs
@@ -26,8 +26,7 @@ use num_traits::{
     CheckedEuclid, Euclid, Inv, MulAdd, MulAddAssign, Num, NumCast,
 };
 
-#[cfg(feature = "alloc")]
-#[allow(unused_imports)]
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 // TODO: AsPrimitive

--- a/src/support/num_traits.rs
+++ b/src/support/num_traits.rs
@@ -26,6 +26,10 @@ use num_traits::{
     CheckedEuclid, Euclid, Inv, MulAdd, MulAddAssign, Num, NumCast,
 };
 
+#[cfg(feature = "alloc")]
+#[allow(unused_imports)]
+use alloc::vec::Vec;
+
 // TODO: AsPrimitive
 
 // Note. We can not implement `NumBytes` as it requires T to be `AsMut<[u8]>`.


### PR DESCRIPTION
## Motivation

I ran into the problem below when I wanted to use num-traits in a no-std (riscv64imac-unknown-none-elf) environment.

```
Compiling ruint v1.12.1
error[E0412]: cannot find type `Vec` in this scope
  --> /home/xcshuan/.cargo/registry/src/github.com-1ecc6299db9ec823/ruint-1.12.1/src/support/num_traits.rs:80:18
   |
80 |     type Bytes = Vec<u8>;
   |                  ^^^ not found in this scope
   |
help: consider importing this struct
   |
7  + use alloc::vec::Vec;
   |

For more information about this error, try `rustc --explain E0412`.
error: could not compile `ruint` (lib) due to 1 previous error
```

## Solution

Add the following import code to `num_traits.rs`.

```
#[cfg(feature = "alloc")]
#[allow(unused_imports)]
use alloc::vec::Vec;
```

## PR Checklist

