### PR TITLE
perf: use borrowing/carrying ops in add/sub, remove bound checks in shifts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use borrowing/carrying ops in add/sub, remove bound checks in shifts ([#366])
+
 ### Fixed
 
-- add `alloc` requirement to `num-traits` feature  [#363]
+- Add `alloc` requirement to `num-traits` feature [#363]
 
 [#363]: https://github.com/recmo/uint/pull/363
+[#366]: https://github.com/recmo/uint/pull/366
 
 ## [1.12.1] - 2024-03-12
 

--- a/src/algorithms/div/knuth.rs
+++ b/src/algorithms/div/knuth.rs
@@ -5,7 +5,6 @@ use crate::{
     algorithms::{add::adc_n, mul::submul_nx1},
     utils::{likely, unlikely},
 };
-use core::u64;
 
 /// ⚠️ In-place Knuth normalized long division with reciprocals.
 ///

--- a/src/from.rs
+++ b/src/from.rs
@@ -601,6 +601,7 @@ macro_rules! to_int {
             type Error = FromUintError<Self>;
 
             #[inline]
+            #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
             fn try_from(value: &Uint<BITS, LIMBS>) -> Result<Self, Self::Error> {
                 const SIGNED: bool = <$int>::MIN != 0;
                 const CAPACITY: usize = if SIGNED { <$int>::BITS - 1 } else { <$int>::BITS } as usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@
     clippy::unreadable_literal,
     clippy::let_unit_value,
     clippy::option_if_let_else,
+    clippy::cast_sign_loss,
+    clippy::cast_lossless,
 )]
 #![cfg_attr(
     any(test, feature = "bench"),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -75,6 +75,30 @@ macro_rules! impl_bin_op {
     };
 }
 
+macro_rules! assume {
+    ($e:expr $(,)?) => {
+        if !$e {
+            debug_unreachable!(stringify!($e));
+        }
+    };
+
+    ($e:expr, $($t:tt)+) => {
+        if !$e {
+            debug_unreachable!($($t)+);
+        }
+    };
+}
+
+macro_rules! debug_unreachable {
+    ($($t:tt)*) => {
+        if cfg!(debug_assertions) {
+            unreachable!($($t)*);
+        } else {
+            unsafe { core::hint::unreachable_unchecked() };
+        }
+    };
+}
+
 #[cfg(test)]
 mod tests {
     // https://github.com/recmo/uint/issues/359


### PR DESCRIPTION
Now `add`, `sub`, and `mul` have optimal codegen on x86_64.