### PR TITLE
chore: reduce inline(always) in algorithms

### DIFF
--- a/src/algorithms/div/mod.rs
+++ b/src/algorithms/div/mod.rs
@@ -44,7 +44,7 @@ use crate::algorithms::DoubleWord;
 /// # Panics
 ///
 /// Panics if `divisor` is zero.
-#[inline(always)]
+#[inline]
 pub fn div(numerator: &mut [u64], divisor: &mut [u64]) {
     // Trim most significant zeros from divisor.
     let i = divisor

--- a/src/algorithms/div/reciprocal.rs
+++ b/src/algorithms/div/reciprocal.rs
@@ -47,14 +47,14 @@ pub fn reciprocal_ref(d: u64) -> u64 {
 ///
 /// [MG10]: https://gmplib.org/~tege/division-paper.pdf
 /// [intx]: https://github.com/chfast/intx/blob/8b5f4748a7386a9530769893dae26b3273e0ffe2/include/intx/intx.hpp#L683
-#[inline(always)]
+#[inline]
 #[must_use]
 pub fn reciprocal_mg10(d: u64) -> u64 {
     const ZERO: Wrapping<u64> = Wrapping(0);
     const ONE: Wrapping<u64> = Wrapping(1);
 
     // Lookup table for $\floor{\frac{2^{19} -3 ⋅ 2^8}{d_9 - 256}}$
-    const TABLE: [u16; 256] = [
+    static TABLE: [u16; 256] = [
         2045, 2037, 2029, 2021, 2013, 2005, 1998, 1990, 1983, 1975, 1968, 1960, 1953, 1946, 1938,
         1931, 1924, 1917, 1910, 1903, 1896, 1889, 1883, 1876, 1869, 1863, 1856, 1849, 1843, 1836,
         1830, 1824, 1817, 1811, 1805, 1799, 1792, 1786, 1780, 1774, 1768, 1762, 1756, 1750, 1745,
@@ -101,7 +101,7 @@ pub fn reciprocal_mg10(d: u64) -> u64 {
 /// Implements [MG10] algorithm 6.
 ///
 /// [MG10]: https://gmplib.org/~tege/division-paper.pdf
-#[inline(always)]
+#[inline]
 #[must_use]
 pub fn reciprocal_2_mg10(d: u128) -> u64 {
     debug_assert!(d >= (1 << 127));
@@ -135,7 +135,7 @@ pub fn reciprocal_2_mg10(d: u128) -> u64 {
 }
 
 #[allow(clippy::missing_const_for_fn)] // False positive
-#[inline(always)]
+#[inline]
 #[must_use]
 fn mul_hi(a: Wrapping<u64>, b: Wrapping<u64>) -> Wrapping<u64> {
     let a = u128::from(a.0);
@@ -145,7 +145,7 @@ fn mul_hi(a: Wrapping<u64>, b: Wrapping<u64>) -> Wrapping<u64> {
 }
 
 #[allow(clippy::missing_const_for_fn)] // False positive
-#[inline(always)]
+#[inline]
 #[must_use]
 fn muladd_hi(a: Wrapping<u64>, b: Wrapping<u64>, c: Wrapping<u64>) -> Wrapping<u64> {
     let a = u128::from(a.0);

--- a/src/algorithms/div/small.rs
+++ b/src/algorithms/div/small.rs
@@ -19,7 +19,7 @@ pub use self::{div_2x1_mg10 as div_2x1, div_3x2_mg10 as div_3x2};
 /// The divisor must be normalized. See algorithm 7 from [MG10].
 ///
 /// [MG10]: https://gmplib.org/~tege/division-paper.pdf
-#[inline(always)]
+#[inline]
 pub fn div_nx1_normalized(u: &mut [u64], d: u64) -> u64 {
     // OPT: Version with in-place shifting of `u`
     debug_assert!(d >= (1 << 63));
@@ -47,7 +47,7 @@ pub fn div_nx1_normalized(u: &mut [u64], d: u64) -> u64 {
 ///
 /// May panics if the above requirements are not met.
 // TODO: Rewrite in a way that avoids bounds-checks without unsafe.
-#[inline(always)]
+#[inline]
 pub fn div_nx1(limbs: &mut [u64], divisor: u64) -> u64 {
     debug_assert!(divisor != 0);
     debug_assert!(!limbs.is_empty());
@@ -91,7 +91,7 @@ pub fn div_nx1(limbs: &mut [u64], divisor: u64) -> u64 {
 ///
 /// Requires `divisor` to be in the range $[2^{127}, 2^{128})$ (i.e.
 /// normalized). Same as [`div_nx1`] but using [`div_3x2`] internally.
-#[inline(always)]
+#[inline]
 pub fn div_nx2_normalized(u: &mut [u64], d: u128) -> u128 {
     // OPT: Version with in-place shifting of `u`
     debug_assert!(d >= (1 << 127));
@@ -115,7 +115,7 @@ pub fn div_nx2_normalized(u: &mut [u64], d: u128) -> u128 {
 ///
 /// May panics if the above requirements are not met.
 // TODO: Rewrite in a way that avoids bounds-checks without unsafe.
-#[inline(always)]
+#[inline]
 pub fn div_nx2(limbs: &mut [u64], divisor: u128) -> u128 {
     debug_assert!(divisor >= 1 << 64);
     debug_assert!(!limbs.is_empty());
@@ -153,7 +153,7 @@ pub fn div_nx2(limbs: &mut [u64], divisor: u128) -> u128 {
     remainder >> shift
 }
 
-#[inline(always)]
+#[inline]
 #[must_use]
 pub fn div_2x1_ref(u: u128, d: u64) -> (u64, u64) {
     debug_assert!(d >= (1 << 63));
@@ -174,7 +174,7 @@ pub fn div_2x1_ref(u: u128, d: u64) -> (u64, u64) {
 /// Implements algorithm 4 from [MG10].
 ///
 /// [MG10]: https://gmplib.org/~tege/division-paper.pdf
-#[inline(always)]
+#[inline]
 #[must_use]
 pub fn div_2x1_mg10(u: u128, d: u64, v: u64) -> (u64, u64) {
     debug_assert!(d >= (1 << 63));
@@ -199,7 +199,7 @@ pub fn div_2x1_mg10(u: u128, d: u64, v: u64) -> (u64, u64) {
 }
 
 /// TODO: This implementation is off by one.
-#[inline(always)]
+#[inline]
 #[must_use]
 pub fn div_3x2_ref(n21: u128, n0: u64, d: u128) -> u64 {
     debug_assert!(d >= (1 << 127));
@@ -252,7 +252,7 @@ pub fn div_3x2_ref(n21: u128, n0: u64, d: u128) -> u64 {
 /// Implements [MG10] algorithm 5.
 ///
 /// [MG10]: https://gmplib.org/~tege/division-paper.pdf
-#[inline(always)]
+#[inline]
 #[must_use]
 pub fn div_3x2_mg10(u21: u128, u0: u64, d: u128, v: u64) -> (u64, u128) {
     debug_assert!(d >= (1 << 127));

--- a/src/algorithms/mul.rs
+++ b/src/algorithms/mul.rs
@@ -62,7 +62,7 @@ pub fn addmul_ref(result: &mut [u64], a: &[u64], b: &[u64]) -> bool {
 /// assert_eq!(overflow, false);
 /// assert_eq!(result, [12]);
 /// ```
-#[inline(always)]
+#[inline]
 pub fn addmul(mut lhs: &mut [u64], mut a: &[u64], mut b: &[u64]) -> bool {
     // Trim zeros from `a`
     while let [0, rest @ ..] = a {
@@ -116,7 +116,7 @@ pub fn addmul(mut lhs: &mut [u64], mut a: &[u64], mut b: &[u64]) -> bool {
 }
 
 /// Computes `lhs += a` and returns the carry.
-#[inline(always)]
+#[inline]
 pub fn add_nx1(lhs: &mut [u64], mut a: u64) -> u64 {
     if a == 0 {
         return 0;
@@ -244,7 +244,7 @@ pub fn mul_nx1(lhs: &mut [u64], a: u64) -> u64 {
 /// \\\\ \mathsf{carry} &= \floor{\frac{\mathsf{lhs} + \mathsf{a} ⋅ \mathsf{b}
 /// }{2^{64⋅N}}} \end{aligned}
 /// $$
-#[inline(always)]
+#[inline]
 pub fn addmul_nx1(lhs: &mut [u64], a: &[u64], b: u64) -> u64 {
     debug_assert_eq!(lhs.len(), a.len());
     let mut carry = 0;
@@ -267,7 +267,7 @@ pub fn addmul_nx1(lhs: &mut [u64], a: &[u64], b: u64) -> u64 {
 /// \mathsf{lhs}}{2^{64⋅N}}} \end{aligned}
 /// $$
 // OPT: `carry` and `borrow` can probably be merged into a single var.
-#[inline(always)]
+#[inline]
 pub fn submul_nx1(lhs: &mut [u64], a: &[u64], b: u64) -> u64 {
     debug_assert_eq!(lhs.len(), a.len());
     let mut carry = 0;


### PR DESCRIPTION
No benefit to inlining big algorithms since they won't get optimized further and only bloat the callsite. Leave up just the inline hint rather than forcing it.