### PR TITLE
perf: re-inline always addmul

### DIFF
--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -20,7 +20,7 @@ pub use self::{
     add::{adc_n, sbb_n},
     div::div,
     gcd::{gcd, gcd_extended, inv_mod, LehmerMatrix},
-    mul::{add_nx1, addmul, addmul_n, addmul_nx1, addmul_ref, mul_nx1, submul_nx1},
+    mul::{add_nx1, addmul, addmul_n, addmul_nx1, mul_nx1, submul_nx1},
     ops::{adc, sbb},
     shift::{shift_left_small, shift_right_small},
 };


### PR DESCRIPTION
Turns out addmul is not that big as I thought, and inlining it provides a decent speed up, unlike division. Partially reverts https://github.com/recmo/uint/pull/374.

I also made addmul_ref test-only as the comment suggests.