### PR TITLE
chore: remove TODOs about proptest cases

### DIFF
--- a/src/algorithms/gcd/matrix.rs
+++ b/src/algorithms/gcd/matrix.rs
@@ -445,9 +445,7 @@ mod tests {
         const_for!(BITS in SIZES {
             const LIMBS: usize = nlimbs(BITS);
             type U = Uint<BITS, LIMBS>;
-            // TODO: Increase cases when perf is better.
-            let mut config = Config::default();
-            config.cases = min(config.cases, if BITS > 500 { 12 } else { 40 });
+            let config = Config { cases: 10, ..Default::default() };
             proptest!(config, |(a: U, b: U)| {
                 test_form_uint_one(a, b);
             });

--- a/src/algorithms/gcd/mod.rs
+++ b/src/algorithms/gcd/mod.rs
@@ -191,7 +191,6 @@ pub fn inv_mod<const BITS: usize, const LIMBS: usize>(
 mod tests {
     use super::*;
     use crate::{const_for, nlimbs};
-    use core::cmp::min;
     use proptest::{proptest, test_runner::Config};
 
     #[test]
@@ -223,9 +222,7 @@ mod tests {
         const_for!(BITS in SIZES {
             const LIMBS: usize = nlimbs(BITS);
             type U = Uint<BITS, LIMBS>;
-            // TODO: Increase cases when perf is better.
-            let mut config = Config::default();
-            config.cases = min(config.cases, if BITS > 500 { 9 } else { 30 });
+            let config = Config { cases: 10, ..Default::default()};
             proptest!(config, |(a: U, b: U)| {
                 assert_eq!(gcd(a, b), gcd_ref(a, b));
             });
@@ -233,14 +230,11 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::absurd_extreme_comparisons)] // Generated code
     fn test_gcd_extended() {
         const_for!(BITS in SIZES {
             const LIMBS: usize = nlimbs(BITS);
             type U = Uint<BITS, LIMBS>;
-            // TODO: Increase cases when perf is better.
-            let mut config = Config::default();
-            config.cases = min(config.cases, if BITS > 500 { 3 } else { 10 });
+            let config = Config { cases: 5, ..Default::default() };
             proptest!(config, |(a: U, b: U)| {
                 let (g, x, y, sign) = gcd_extended(a, b);
                 assert_eq!(g, gcd_ref(a, b));

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -840,7 +840,7 @@ mod tests {
             type U = Uint::<BITS, LIMBS>;
             proptest!(|(value: U, shift in  0..=BITS + 2)| {
                 let shifted = value.arithmetic_shr(shift);
-                dbg!(value, shifted, shift);
+                // dbg!(value, shifted, shift);
                 assert_eq!(shifted.leading_ones(), match value.leading_ones() {
                     0 => 0,
                     n => min(BITS, n + shift)

--- a/src/gcd.rs
+++ b/src/gcd.rs
@@ -53,7 +53,6 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
 mod tests {
     use super::*;
     use crate::{const_for, nlimbs};
-    use core::cmp::min;
     use proptest::{proptest, test_runner::Config};
 
     #[test]
@@ -62,9 +61,7 @@ mod tests {
         const_for!(BITS in SIZES {
             const LIMBS: usize = nlimbs(BITS);
             type U = Uint<BITS, LIMBS>;
-            // TODO: Increase cases when perf is better.
-            let mut config = Config::default();
-            config.cases = min(config.cases, if BITS > 500 { 3 } else { 10 });
+            let config = Config { cases: 5, ..Default::default() };
             proptest!(config, |(a: U, b: U)| {
                 let g = a.gcd(b);
                 assert_eq!(b.gcd(a), g);


### PR DESCRIPTION
Cases are reduced due to complex algorithms that are not really going to get any better any time soon.

- Closes #107
- Closes #141
- Closes #142
- Closes #143
- Closes #144
- Closes #145