### PR TITLE
Bump sqlx 0.7 -> 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for sqlx @ 0.8 ([#400])
+
+### Removed
+
+- Support for sqlx @ 0.7. This is a breaking change, outside of 
+  regular semver policy, as 0.7 contains a security vulnerability  ([#400])
+
+[#400]: https://github.com/recmo/uint/pull/400
+
 ## [1.12.3] - 2024-06-03
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ bytes = { version = "1.4", optional = true }
 postgres-types = { version = "0.2", optional = true }
 
 # sqlx
-sqlx-core = { version = "0.7", optional = true }
+sqlx-core = { version = "0.8.2", optional = true }
 
 [dev-dependencies]
 ruint = { path = ".", features = ["arbitrary", "proptest"] }

--- a/src/support/scale.rs
+++ b/src/support/scale.rs
@@ -97,7 +97,7 @@ impl<'a, const BITS: usize, const LIMBS: usize> EncodeAsRef<'a, Uint<BITS, LIMBS
     type RefType = CompactRefUint<'a, BITS, LIMBS>;
 }
 
-impl<'a, const BITS: usize, const LIMBS: usize> EncodeLike for CompactRefUint<'a, BITS, LIMBS> {}
+impl<const BITS: usize, const LIMBS: usize> EncodeLike for CompactRefUint<'_, BITS, LIMBS> {}
 
 /// Compact/general integers are encoded with the two least significant bits
 /// denoting the mode:
@@ -112,7 +112,7 @@ impl<'a, const BITS: usize, const LIMBS: usize> EncodeLike for CompactRefUint<'a
 ///   following, plus four. The  value is contained, LE encoded, in the bytes
 ///   following. The final (most  significant) byte must be non-zero. Valid only
 ///   for values of `(2\*\*30)-(2\*\*536-1)`.
-impl<'a, const BITS: usize, const LIMBS: usize> Encode for CompactRefUint<'a, BITS, LIMBS> {
+impl<const BITS: usize, const LIMBS: usize> Encode for CompactRefUint<'_, BITS, LIMBS> {
     fn size_hint(&self) -> usize {
         match self.0.bit_len() {
             0..=6 => 1,

--- a/src/support/serde.rs
+++ b/src/support/serde.rs
@@ -100,7 +100,7 @@ impl<'de, const BITS: usize, const LIMBS: usize> Deserialize<'de> for Bits<BITS,
 /// Accepts either a primitive number, a decimal or a hexadecimal string.
 struct HrVisitor<const BITS: usize, const LIMBS: usize>;
 
-impl<'de, const BITS: usize, const LIMBS: usize> Visitor<'de> for HrVisitor<BITS, LIMBS> {
+impl<const BITS: usize, const LIMBS: usize> Visitor<'_> for HrVisitor<BITS, LIMBS> {
     type Value = Uint<BITS, LIMBS>;
 
     fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
@@ -136,7 +136,7 @@ impl<'de, const BITS: usize, const LIMBS: usize> Visitor<'de> for HrVisitor<BITS
 /// Serde Visitor for non-human readable formats
 struct ByteVisitor<const BITS: usize, const LIMBS: usize>;
 
-impl<'de, const BITS: usize, const LIMBS: usize> Visitor<'de> for ByteVisitor<BITS, LIMBS> {
+impl<const BITS: usize, const LIMBS: usize> Visitor<'_> for ByteVisitor<BITS, LIMBS> {
     type Value = Uint<BITS, LIMBS>;
 
     fn expecting(&self, formatter: &mut Formatter) -> FmtResult {

--- a/src/support/sqlx.rs
+++ b/src/support/sqlx.rs
@@ -5,15 +5,14 @@
 #![cfg(feature = "sqlx")]
 #![cfg_attr(docsrs, doc(cfg(feature = "sqlx")))]
 
-use crate::Uint;
-use sqlx_core::{
-    database::{Database, HasArguments, HasValueRef},
-    decode::Decode,
-    encode::{Encode, IsNull},
-    error::BoxDynError,
-    types::Type,
-};
+use sqlx_core::database::Database;
+use sqlx_core::decode::Decode;
+use sqlx_core::encode::{Encode, IsNull};
+use sqlx_core::error::BoxDynError;
+use sqlx_core::types::Type;
 use thiserror::Error;
+
+use crate::Uint;
 
 #[derive(Error, Debug)]
 pub enum DecodeError {
@@ -38,7 +37,10 @@ impl<'a, const BITS: usize, const LIMBS: usize, DB: Database> Encode<'a, DB> for
 where
     Vec<u8>: Encode<'a, DB>,
 {
-    fn encode_by_ref(&self, buf: &mut <DB as HasArguments<'a>>::ArgumentBuffer) -> IsNull {
+    fn encode_by_ref(
+        &self,
+        buf: &mut <DB as Database>::ArgumentBuffer<'a>,
+    ) -> Result<IsNull, BoxDynError> {
         self.to_be_bytes_vec().encode_by_ref(buf)
     }
 }
@@ -47,7 +49,7 @@ impl<'a, const BITS: usize, const LIMBS: usize, DB: Database> Decode<'a, DB> for
 where
     Vec<u8>: Decode<'a, DB>,
 {
-    fn decode(value: <DB as HasValueRef<'a>>::ValueRef) -> Result<Self, BoxDynError> {
+    fn decode(value: <DB as Database>::ValueRef<'a>) -> Result<Self, BoxDynError> {
         let bytes = Vec::<u8>::decode(value)?;
         Self::try_from_be_slice(bytes.as_slice()).ok_or_else(|| DecodeError::Overflow.into())
     }

--- a/src/support/sqlx.rs
+++ b/src/support/sqlx.rs
@@ -5,11 +5,13 @@
 #![cfg(feature = "sqlx")]
 #![cfg_attr(docsrs, doc(cfg(feature = "sqlx")))]
 
-use sqlx_core::database::Database;
-use sqlx_core::decode::Decode;
-use sqlx_core::encode::{Encode, IsNull};
-use sqlx_core::error::BoxDynError;
-use sqlx_core::types::Type;
+use sqlx_core::{
+    database::Database,
+    decode::Decode,
+    encode::{Encode, IsNull},
+    error::BoxDynError,
+    types::Type,
+};
 use thiserror::Error;
 
 use crate::Uint;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

Older versions of sqlx contain a [vulnerability](https://rustsec.org/advisories/RUSTSEC-2024-0363.html)

## Solution

This vulnerability has been patched in >=0.8.1
