### PR TITLE
feat: support for diesel @ 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#399]: https://github.com/recmo/uint/pull/399
 [#400]: https://github.com/recmo/uint/pull/400
 [#401]: https://github.com/recmo/uint/pull/401
+[#404]: https://github.com/recmo/uint/pull/404
 
 ## [1.12.3] - 2024-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for diesel @ 2.2 ([#TODO])
 - Support for sqlx @ 0.8 ([#400])
 - Support for fastrlp @ 0.4 ([#401])
 - Added support for [`subtle`](https://docs.rs/subtle) and [`der`](https://docs.rs/der) ([#399])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support for diesel @ 2.2 ([#TODO])
+- Support for diesel @ 2.2 ([#404])
 - Support for sqlx @ 0.8 ([#400])
 - Support for fastrlp @ 0.4 ([#401])
 - Added support for [`subtle`](https://docs.rs/subtle) and [`der`](https://docs.rs/der) ([#399])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,9 @@ subtle = { version = "2.6.1", optional = true, default-features = false }
 bytes = { version = "1.4", optional = true }
 postgres-types = { version = "0.2", optional = true }
 
+# diesel
+diesel = { version = "2.2", optional = true }
+
 # sqlx
 sqlx-core = { version = "0.8.2", optional = true }
 
@@ -148,6 +151,7 @@ ark-ff-04 = ["dep:ark-ff-04"]
 bn-rs = ["dep:bn-rs", "std"]
 bytemuck = ["dep:bytemuck"]
 der = ["dep:der", "alloc"]                                             # TODO: also have alloc free der impls.
+diesel = ["dep:diesel", "std", "dep:thiserror"]
 fastrlp = ["dep:fastrlp-03", "alloc"]
 fastrlp-04 = ["dep:fastrlp-04", "alloc"]
 num-bigint = ["dep:num-bigint", "alloc"]

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ named feature flag.
 * [`num-traits`](https://docs.rs/num-traits): Implements about forty applicable traits.
 * [`subtle`](https://docs.rs/subtle): Implements [`Uint::bit_ct`], [`ConditionallySelectable`](https://docs.rs/subtle/latest/subtle/trait.ConditionallySelectable.html),[`ConditionallyNegatable`](https://docs.rs/subtle/latest/subtle/trait.ConditionallyNegatable.html), [`ConstantTimeEq`](https://docs.rs/subtle/latest/subtle/trait.ConstantTimeEq.html)/[`ConstantTimeGreater`](https://docs.rs/subtle/latest/subtle/trait.ConstantTimeGreater.html)/[`ConstantTimeLess`](https://docs.rs/subtle/latest/subtle/trait.ConstantTimeLess.html).
 * [`der`](https://docs.rs/der): Implements [`Encode`](https://docs.rs/der/latest/der/trait.Encode.html)/[`Decode`](https://docs.rs/der/latest/der/trait.Decode.html) and [`TryFrom`]/[`From`] casting for [`Any`](https://docs.rs/der/latest/der/asn1/struct.Any.html), [`AnyRef`](https://docs.rs/der/latest/der/asn1/struct.AnyRef.html), [`Int`](https://docs.rs/der/latest/der/asn1/struct.Int.html), [`IntRef`](https://docs.rs/der/latest/der/asn1/struct.IntRef.html), [`Uint`](https://docs.rs/der/latest/der/asn1/struct.Uint.html), [`UintRef`](https://docs.rs/der/latest/der/asn1/struct.UintRef.html).
+* [`diesel`](https://docs.rs/diesel): Implements the [`ToSql`](https://docs.rs/diesel/latest/diesel/serialize/trait.ToSql.html) and [`FromSql`](https://docs.rs/diesel/latest/diesel/deserialize/trait.FromSql.html) traits for storing `Uint` values as byte arrays in databases supported by Diesel.
 
 ## Building and testing
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,8 +144,6 @@ pub mod nightly {
 ///
 /// [std-overflow]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#overflow
 #[derive(Clone, Copy, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "diesel", derive(diesel::AsExpression, diesel::FromSqlRow))]
-#[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Binary))]
 #[repr(transparent)]
 pub struct Uint<const BITS: usize, const LIMBS: usize> {
     limbs: [u64; LIMBS],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,8 @@ pub mod nightly {
 ///
 /// [std-overflow]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#overflow
 #[derive(Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "diesel", derive(diesel::AsExpression, diesel::FromSqlRow))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Binary))]
 #[repr(transparent)]
 pub struct Uint<const BITS: usize, const LIMBS: usize> {
     limbs: [u64; LIMBS],

--- a/src/support/diesel.rs
+++ b/src/support/diesel.rs
@@ -8,9 +8,12 @@
 use diesel::{
     backend::Backend,
     deserialize::{self, FromSql},
+    expression::AsExpression,
+    internal::derives::as_expression::Bound,
     query_builder::bind_collector::RawBytesBindCollector,
     serialize::{self, IsNull, Output, ToSql},
-    sql_types::Binary,
+    sql_types::{Binary, Nullable, SingleValue},
+    Queryable,
 };
 use std::io::Write;
 use thiserror::Error;
@@ -41,5 +44,76 @@ where
         let bytes: *const [u8] = FromSql::<Binary, DB>::from_sql(bytes)?;
         let bytes: &[u8] = unsafe { &*bytes };
         Self::try_from_be_slice(bytes).ok_or_else(|| DecodeError::Overflow.into())
+    }
+}
+
+impl<'__expr, const BITS: usize, const LIMBS: usize> AsExpression<Binary>
+    for &'__expr Uint<BITS, LIMBS>
+{
+    type Expression = Bound<Binary, Self>;
+    fn as_expression(self) -> Self::Expression {
+        Bound::new(self)
+    }
+}
+
+impl<'__expr, const BITS: usize, const LIMBS: usize> AsExpression<Nullable<Binary>>
+    for &'__expr Uint<BITS, LIMBS>
+{
+    type Expression = Bound<Nullable<Binary>, Self>;
+    fn as_expression(self) -> Self::Expression {
+        Bound::new(self)
+    }
+}
+impl<'__expr, '__expr2, const BITS: usize, const LIMBS: usize> AsExpression<Binary>
+    for &'__expr2 &'__expr Uint<BITS, LIMBS>
+{
+    type Expression = Bound<Binary, Self>;
+    fn as_expression(self) -> Self::Expression {
+        Bound::new(self)
+    }
+}
+impl<'__expr, '__expr2, const BITS: usize, const LIMBS: usize> AsExpression<Nullable<Binary>>
+    for &'__expr2 &'__expr Uint<BITS, LIMBS>
+{
+    type Expression = Bound<Nullable<Binary>, Self>;
+    fn as_expression(self) -> Self::Expression {
+        Bound::new(self)
+    }
+}
+
+impl<const BITS: usize, const LIMBS: usize, __DB> diesel::serialize::ToSql<Nullable<Binary>, __DB>
+    for Uint<BITS, LIMBS>
+where
+    __DB: Backend,
+    Self: ToSql<Binary, __DB>,
+{
+    fn to_sql<'__b>(&'__b self, out: &mut Output<'__b, '_, __DB>) -> serialize::Result {
+        ToSql::<Binary, __DB>::to_sql(self, out)
+    }
+}
+
+impl<const BITS: usize, const LIMBS: usize> AsExpression<Binary> for Uint<BITS, LIMBS> {
+    type Expression = Bound<Binary, Self>;
+    fn as_expression(self) -> Self::Expression {
+        Bound::new(self)
+    }
+}
+
+impl<const BITS: usize, const LIMBS: usize> AsExpression<Nullable<Binary>> for Uint<BITS, LIMBS> {
+    type Expression = Bound<Nullable<Binary>, Self>;
+    fn as_expression(self) -> Self::Expression {
+        Bound::new(self)
+    }
+}
+
+impl<const BITS: usize, const LIMBS: usize, __DB, __ST> Queryable<__ST, __DB> for Uint<BITS, LIMBS>
+where
+    __DB: Backend,
+    __ST: SingleValue,
+    Self: FromSql<__ST, __DB>,
+{
+    type Row = Self;
+    fn build(row: Self::Row) -> deserialize::Result<Self> {
+        Ok(row)
     }
 }

--- a/src/support/diesel.rs
+++ b/src/support/diesel.rs
@@ -1,0 +1,45 @@
+//! Support for the [`diesel`](https://crates.io/crates/diesel) crate.
+//!
+//! Currently only encodes to/from a big-endian byte array.
+
+#![cfg(feature = "diesel")]
+#![cfg_attr(docsrs, doc(cfg(feature = "diesel")))]
+
+use diesel::{
+    backend::Backend,
+    deserialize::{self, FromSql},
+    query_builder::bind_collector::RawBytesBindCollector,
+    serialize::{self, IsNull, Output, ToSql},
+    sql_types::Binary,
+};
+use std::io::Write;
+use thiserror::Error;
+
+use crate::Uint;
+
+#[derive(Error, Debug)]
+pub enum DecodeError {
+    #[error("Value too large for target type")]
+    Overflow,
+}
+
+impl<const BITS: usize, const LIMBS: usize, DB: Backend> ToSql<Binary, DB> for Uint<BITS, LIMBS>
+where
+    for<'c> DB: Backend<BindCollector<'c> = RawBytesBindCollector<DB>>,
+{
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, DB>) -> serialize::Result {
+        out.write_all(&self.to_be_bytes_vec())?;
+        Ok(IsNull::No)
+    }
+}
+
+impl<const BITS: usize, const LIMBS: usize, DB: Backend> FromSql<Binary, DB> for Uint<BITS, LIMBS>
+where
+    *const [u8]: FromSql<Binary, DB>,
+{
+    fn from_sql(bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
+        let bytes: *const [u8] = FromSql::<Binary, DB>::from_sql(bytes)?;
+        let bytes: &[u8] = unsafe { &*bytes };
+        Self::try_from_be_slice(bytes).ok_or_else(|| DecodeError::Overflow.into())
+    }
+}

--- a/src/support/mod.rs
+++ b/src/support/mod.rs
@@ -9,6 +9,7 @@ mod ark_ff_04;
 mod bn_rs;
 mod bytemuck;
 mod der;
+pub mod diesel;
 mod fastrlp_03;
 mod fastrlp_04;
 mod num_bigint;
@@ -44,6 +45,3 @@ mod zeroize;
 // * wasm-bindgen `JsValue` bigint: https://docs.rs/wasm-bindgen/latest/wasm_bindgen/struct.JsValue.html#method.bigint_from_str
 //   or from_f64.
 // * Neon `JsBigInt` once it lands: https://github.com/neon-bindings/neon/pull/861
-
-// More databases:
-// * https://crates.io/crates/diesel


### PR DESCRIPTION
## Motivation

I noticed there were some comment notes in the repo indicating a desire for diesel support. I had implemented something similar using a newtype pattern in my own project, so I figured I'd attempt to contribute it back upstream.

## Solution

This PR implements the required traits for the generic uint types to work out of the box with diesel. The implementation closely matches the sqlx feature implementation in this repo. I have an example repo illustrating simple usage (schema, querying, inserting) @ https://github.com/sinasab/diesel_uint_test/.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
