### PR TITLE
feat: add `copy_*e_to_slice` family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - Support for borsh @ 1.5 ([#416])
+- `copy_le_to_slice` family to allow easier writing to pre-allocated buffers ([#423])
+
+[#416]: https://github.com/recmo/uint/pull/416
+[#423]: https://github.com/recmo/uint/pull/423
 
 ## [1.12.4] - 2024-12-16
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -345,6 +345,102 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         }
         Some(Self::from_limbs(limbs))
     }
+
+    /// Writes the little-endian representation of the [`Uint`] to the given
+    /// buffer. The buffer must be large enough to hold [`Self::BYTES`] bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not large enough to hold [`Self::BYTES`] bytes.
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes written to the buffer (always equal to
+    /// [`Self::BYTES`]), but often useful to make explicit for encoders).
+    pub fn copy_le_bytes_to(&self, buf: &mut [u8]) -> usize {
+        // This is debug only. Release panics occur later in copy_from_slice
+        debug_assert!(
+            buf.len() >= Self::BYTES,
+            "Buffer is too small to hold the bytes of the Uint"
+        );
+
+        let chunks = &mut buf[..Self::BYTES].chunks_mut(8);
+
+        self.limbs.iter().zip(chunks).for_each(|(&limb, chunk)| {
+            let le = limb.to_le_bytes();
+            chunk.copy_from_slice(&le[..chunk.len()]);
+        });
+
+        Self::BYTES
+    }
+
+    /// writes the little-endian representation of the [`Uint`] to the given
+    /// buffer. The buffer must be large enough to hold [`Self::BYTES`] bytes.
+    ///
+    /// # Returns
+    ///
+    /// [`None`], if the buffer is not large enough to hold [`Self::BYTES`]
+    /// bytes, and does not modify the buffer.
+    ///
+    /// [`Some`] with the number of bytes written to the buffer (always
+    /// equal to [`Self::BYTES`]), but often useful to make explicit for
+    /// encoders.
+    pub fn checked_copy_le_bytes_to(&self, buf: &mut [u8]) -> Option<usize> {
+        if buf.len() < Self::BYTES {
+            return None;
+        }
+
+        Some(self.copy_le_bytes_to(buf))
+    }
+
+    /// Writes the big-endian representation of the [`Uint`] to the given
+    /// buffer. The buffer must be large enough to hold [`Self::BYTES`] bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not large enough to hold [`Self::BYTES`] bytes.
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes written to the buffer (always equal to
+    /// [`Self::BYTES`]), but often useful to make explicit for encoders).
+    pub fn copy_be_bytes_to(&self, buf: &mut [u8]) -> usize {
+        // This is debug only. Release panics occur later in copy_from_slice
+        debug_assert!(
+            buf.len() >= Self::BYTES,
+            "Buffer is too small to hold the bytes of the Uint"
+        );
+
+        // start from the end of the slice
+        let chunks = &mut buf[..Self::BYTES].rchunks_mut(8);
+
+        self.limbs.iter().zip(chunks).for_each(|(&limb, chunk)| {
+            let be = limb.to_be_bytes();
+            let copy_from = 8 - chunk.len();
+            chunk.copy_from_slice(&be[copy_from..]);
+        });
+
+        Self::BYTES
+    }
+
+    /// Writes the big-endian representation of the [`Uint`] to the given
+    /// buffer. The buffer must be large enough to hold [`Self::BYTES`] bytes.
+    ///
+    /// # Returns
+    ///
+    /// [`None`], if the buffer is not large enough to hold [`Self::BYTES`]
+    /// bytes, and does not modify the buffer.
+    ///
+    /// [`Some`] with the number of bytes written to the buffer (always
+    /// equal to [`Self::BYTES`]), but often useful to make explicit for
+    /// encoders.
+    pub fn checked_copy_be_bytes_to(&self, buf: &mut [u8]) -> Option<usize> {
+        if buf.len() < Self::BYTES {
+            return None;
+        }
+
+        Some(self.copy_be_bytes_to(buf))
+    }
 }
 
 /// Number of bytes required to represent the given number of bits.
@@ -486,6 +582,45 @@ mod tests {
                 assert_eq!(value, Uint::from_be_bytes(value.to_be_bytes::<BYTES>()));
                 assert_eq!(value, Uint::from_le_bytes(value.to_le_bytes::<BYTES>()));
             });
+        });
+    }
+
+    #[test]
+    fn copy_to() {
+        const_for!(BITS in SIZES {
+            const LIMBS: usize = nlimbs(BITS);
+            const BYTES: usize = nbytes(BITS);
+            proptest!(|(value: Uint<BITS, LIMBS>)|{
+                let mut buf = [0; BYTES];
+                value.copy_le_bytes_to(&mut buf);
+                assert_eq!(buf, value.to_le_bytes::<BYTES>());
+                assert_eq!(value, Uint::try_from_le_slice(&buf).unwrap());
+
+                let mut buf = [0; BYTES];
+                value.copy_be_bytes_to(&mut buf);
+                assert_eq!(buf, value.to_be_bytes::<BYTES>());
+                assert_eq!(value, Uint::try_from_be_slice(&buf).unwrap());
+            })
+        });
+    }
+
+    #[test]
+    fn checked_copy_to() {
+        const_for!(BITS in SIZES {
+            const LIMBS: usize = nlimbs(BITS);
+            const BYTES: usize = nbytes(BITS);
+            proptest!(|(value: Uint<BITS, LIMBS>)|{
+                if BYTES != 0 {
+                    let mut buf = [0; BYTES];
+                    let too_short = buf.len() - 1;
+
+                    assert_eq!(value.checked_copy_le_bytes_to(&mut buf[..too_short]), None);
+                    assert_eq!(buf, [0; BYTES], "buffer was modified");
+
+                    assert_eq!(value.checked_copy_be_bytes_to(&mut buf[..too_short]), None);
+                    assert_eq!(buf, [0; BYTES], "buffer was modified");
+                }
+            })
         });
     }
 }

--- a/src/support/borsh.rs
+++ b/src/support/borsh.rs
@@ -60,6 +60,7 @@ impl<const BITS: usize, const LIMBS: usize> BorshSerialize for Bits<BITS, LIMBS>
         self.as_uint().serialize(writer)
     }
 }
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION

## Motivation

Add convenient methods for writing Uints to pre-allocated buffers

## Solution

```
fn copy_le_to_slice()
fn checked_copy_le_to_slice()
fn copy_be_to_slice()
fn checked_copy_be_to_slice()
```

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
