### PR TITLE
chore(deps): unpin proptest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for borsh @ 1.5 ([#416])
 - `copy_le_to_slice` family to allow easier writing to pre-allocated buffers ([#424])
+- Unpin proptest ([#426])
 
 [#416]: https://github.com/recmo/uint/pull/416
 [#424]: https://github.com/recmo/uint/pull/424
+[#426]: https://github.com/recmo/uint/pull/426
 
 ## [1.12.4] - 2024-12-16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,12 +61,14 @@ fastrlp-04 = { version = "0.4", package = "fastrlp", optional = true, default-fe
 num-bigint = { version = "0.4", optional = true, default-features = false }
 num-integer = { version = "0.1", optional = true, default-features = false }
 num-traits = { version = "0.2.16", optional = true, default-features = false }
-parity-scale-codec = { version = "3", optional = true, features = [
+parity-scale-codec = { version = "3", optional = true, default-features = false, features = [
     "derive",
     "max-encoded-len",
-], default-features = false }
+] }
 primitive-types = { version = "0.12", optional = true, default-features = false }
-proptest = { version = "=1.5", optional = true, default-features = false }
+proptest = { version = "1", optional = true, default-features = false, features = [
+    "no_std",
+] }
 pyo3 = { version = "0.19", optional = true, default-features = false }
 quickcheck = { version = "1", optional = true, default-features = false }
 rand = { version = "0.8", optional = true, default-features = false }
@@ -109,7 +111,7 @@ bincode = "1.3"
 hex = "0.4"
 hex-literal = "0.4"
 postgres = "0.19"
-proptest = "=1.5"
+proptest = "1"
 serde_json = "1.0"
 
 # borsh
@@ -158,7 +160,7 @@ ark-ff-04 = ["dep:ark-ff-04"]
 bn-rs = ["dep:bn-rs", "std"]
 borsh = ["dep:borsh"]
 bytemuck = ["dep:bytemuck"]
-der = ["dep:der", "alloc"]                                             # TODO: also have alloc free der impls.
+der = ["dep:der", "alloc"] # TODO: also have alloc free der impls.
 diesel = ["dep:diesel", "std", "dep:thiserror"]
 fastrlp = ["dep:fastrlp-03", "alloc"]
 fastrlp-04 = ["dep:fastrlp-04", "alloc"]
@@ -173,7 +175,7 @@ pyo3 = ["dep:pyo3", "std"]
 quickcheck = ["dep:quickcheck", "std"]
 rand = ["dep:rand"]
 rlp = ["dep:rlp", "alloc"]
-serde = ["dep:serde", "alloc"]                                         # TODO: try to avoid alloc in serde impls
+serde = ["dep:serde", "alloc"] # TODO: try to avoid alloc in serde impls
 sqlx = ["dep:sqlx-core", "std", "dep:thiserror"]
 subtle = ["dep:subtle"]
 valuable = ["dep:valuable"]

--- a/deny.toml
+++ b/deny.toml
@@ -26,6 +26,7 @@ allow = [
     "MPL-2.0",
     "CC0-1.0",
     "Unicode-3.0",
+    "Zlib",
 ]
 
 [sources]


### PR DESCRIPTION
I don't see why it was pinned with `=`. This blocks automatic updates if you already have proptest 1.6 (very likely), as cargo would rather not update ruint than update it and have to downgrade proptest.