### PR TITLE
fix: some docs, and add a checked_byte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for borsh @ 1.5 ([#416])
 - `copy_le_to_slice` family to allow easier writing to pre-allocated buffers ([#424])
 - Unpin proptest ([#426])
+- Update documentation related to `Uint::byte` and knuth divison ([#429])
+- add `Uint::checked_byte(idx: usize) -> Option<u8>` ([#429])
 
 [#416]: https://github.com/recmo/uint/pull/416
 [#424]: https://github.com/recmo/uint/pull/424
 [#426]: https://github.com/recmo/uint/pull/426
+[#429]: https://github.com/recmo/uint/pull/429
 
 ## [1.12.4] - 2024-12-16
 

--- a/src/algorithms/div/knuth.rs
+++ b/src/algorithms/div/knuth.rs
@@ -8,14 +8,15 @@ use crate::{
 
 /// ⚠️ In-place Knuth normalized long division with reciprocals.
 ///
-/// Requires
-/// * the highest bit of the divisor to be set,
-/// * the `divisor` and `numerator` to be at least two limbs, and
-/// * `numerator` is at least as long as `divisor`.
+/// # Conditions of Use
+///
+/// * The highest (most-significant) bit of the divisor MUST be set.
+/// * The `divisor` and `numerator` MUST each be at least two limbs.
+/// * `numerator` MUST contain at at least as many elements as `divisor`.
 ///
 /// # Panics
 ///
-/// May panic if the above requirements are not met.
+/// May panic if any condition of use is violated.
 #[inline]
 #[allow(clippy::many_single_char_names)]
 pub fn div_nxm_normalized(numerator: &mut [u64], divisor: &[u64]) {
@@ -75,14 +76,16 @@ pub fn div_nxm_normalized(numerator: &mut [u64], divisor: &[u64]) {
 
 /// ⚠️ In-place Knuth long division with implicit normalization and reciprocals.
 ///
-/// Requires
-/// * the highest limb of the divisor to be non-zero,
-/// * the `divisor` and `numerator` to be at least two limbs, and
-/// * `numerator` is at least as long as `divisor`.
+/// # Conditions of use:
+///
+/// * `divisor` MUST NOT be empty.
+/// * The highest (most-significant) limb of `divisor` MUST be non-zero.
+/// * `divisor` and `numerator` MUST contain at least three limbs.
+/// * `numerator` MUST contain at at least as many elements as `divisor`.
 ///
 /// # Panics
 ///
-/// May panic if the above requirements are not met.
+/// May panic if any condition of use is violated.
 #[inline]
 #[allow(clippy::many_single_char_names)]
 pub fn div_nxm(numerator: &mut [u64], divisor: &mut [u64]) {

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -37,7 +37,8 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     ///
     /// # Panics
     ///
-    /// Panics if `index` exceeds the byte width of the number.
+    /// Panics if `index` is greater than or equal to the byte width of the
+    /// number.
     ///
     /// # Examples
     ///
@@ -77,6 +78,26 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         #[allow(clippy::cast_possible_truncation)] // intentional
         {
             (self.limbs[index / 8] >> ((index % 8) * 8)) as u8
+        }
+    }
+
+    /// Returns a specific byte, or `None` if `index` is out of range. The byte
+    /// at index `0` is the least significant byte (little endian).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ruint::uint;
+    /// let x = uint!(0x1234567890_U64);
+    /// assert_eq!(x.checked_byte(0), Some(0x90));
+    /// // Out of range
+    /// assert_eq!(x.checked_byte(8), None);
+    /// ```
+    pub fn checked_byte(&self, index: usize) -> Option<u8> {
+        if index >= self.byte_len() {
+            None
+        } else {
+            Some(self.byte(index))
         }
     }
 

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -93,6 +93,8 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// // Out of range
     /// assert_eq!(x.checked_byte(8), None);
     /// ```
+    #[inline]
+    #[must_use]
     pub fn checked_byte(&self, index: usize) -> Option<u8> {
         if index >= self.byte_len() {
             None

--- a/src/support/postgres.rs
+++ b/src/support/postgres.rs
@@ -167,7 +167,7 @@ impl<const BITS: usize, const LIMBS: usize> ToSql for Uint<BITS, LIMBS> {
             _ => {
                 return Err(Box::new(WrongType::new::<Self>(ty.clone())));
             }
-        };
+        }
         Ok(IsNull::No)
     }
 


### PR DESCRIPTION
## Motivation

Closes #428 
adds a drive-by feature to get an `Option<u8>`

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [x] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
