### PR TITLE
fix: swap bytes for `as_le_bytes` in big endian world

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unpin proptest ([#426])
 - Update documentation related to `Uint::byte` and knuth divison ([#429])
 - add `Uint::checked_byte(idx: usize) -> Option<u8>` ([#429])
+- fix: swap bytes for `as_le_bytes` in big endian world ([#431])
 
 [#416]: https://github.com/recmo/uint/pull/416
 [#424]: https://github.com/recmo/uint/pull/424
 [#426]: https://github.com/recmo/uint/pull/426
 [#429]: https://github.com/recmo/uint/pull/429
+[#431]: https://github.com/recmo/uint/pull/431
 
 ## [1.12.4] - 2024-12-16
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -60,7 +60,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         return Cow::Owned({
             let mut cpy = *self;
             for limb in &mut cpy.limbs {
-                *limb = limb.reverse_bits();
+                *limb = limb.swap_bytes();
             }
             unsafe { slice::from_raw_parts(cpy.limbs.as_ptr().cast(), Self::BYTES).to_vec() }
         });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

Was tweaking https://github.com/op-rs/kona which has this repo as a dependency. Compiled kona down to mips64 which is big endian, and spotted this bug while comparing the results with little endian arch.

Minimal reproduction:
```rust
use alloy_primitives::U256;
use alloc::vec::Vec;
use alloy_rlp::Encodable;
...
    let mut out = Vec::<u8>::new();
    U256::from(0x12345678).encode(&mut out); // rlp encodes num
```
When we print `out` variable...
- in little endian, `[132, 18, 52, 86, 120]`, which is correct
- in big endian, `[132, 72, 44, 106, 30]`, which is wrong.
both results must be identical. 

## Solution

Must swap bytes for big endian architectures, not reversing bits. 

## PR Checklist

- [ ] Added Tests
    - Unfortunately, no. We may add test suite or ci pipeline for big endian targets
- [ ] Added Documentation
- [x] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
