### PR TITLE
feat: Constify leading_zeros, leading_ones, count_ones, count_zeros, bit_len, byte_len, is_power_of_two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add const `not` function ([#442])
+- Make `leading_zeros`, `leading_ones`, `count_ones`, `count_zeros`, `bit_len`, `byte_len`, `is_power_of_two` functions `const` ([#442])
+
 ### Changed
 
 - Update `try_from_{b,l}e_slice` documentation ([#439])
@@ -17,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `checked_byte` bounds check and make it const ([#438])
 
+[#442]: https://github.com/recmo/uint/pull/442
 [#439]: https://github.com/recmo/uint/pull/439
 [#438]: https://github.com/recmo/uint/pull/438
 

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -120,29 +120,50 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         self
     }
 
+    /// Inverts all the bits in the integer.
+    #[inline]
+    #[must_use]
+    pub const fn not(mut self) -> Self {
+        if BITS == 0 {
+            return Self::ZERO;
+        }
+
+        let mut i = 0;
+        while i < LIMBS {
+            self.limbs[i] = !self.limbs[i];
+            i += 1;
+        }
+
+        self.limbs[LIMBS - 1] &= Self::MASK;
+        self
+    }
+
     /// Returns the number of leading zeros in the binary representation of
     /// `self`.
     #[inline]
     #[must_use]
-    pub fn leading_zeros(&self) -> usize {
-        self.as_limbs()
-            .iter()
-            .rev()
-            .position(|&limb| limb != 0)
-            .map_or(BITS, |n| {
-                let fixed = Self::MASK.leading_zeros() as usize;
+    pub const fn leading_zeros(&self) -> usize {
+        let mut i = LIMBS;
+        while i > 0 {
+            i -= 1;
+            if self.limbs[i] != 0 {
+                let n = LIMBS - 1 - i;
                 let skipped = n * 64;
-                let top = self.as_limbs()[LIMBS - n - 1].leading_zeros() as usize;
-                skipped + top - fixed
-            })
+                let fixed = Self::MASK.leading_zeros() as usize;
+                let top = self.limbs[i].leading_zeros() as usize;
+                return skipped + top - fixed;
+            }
+        }
+
+        BITS
     }
 
     /// Returns the number of leading ones in the binary representation of
     /// `self`.
     #[inline]
     #[must_use]
-    pub fn leading_ones(&self) -> usize {
-        self.not().leading_zeros()
+    pub const fn leading_ones(&self) -> usize {
+        Self::not(*self).leading_zeros()
     }
 
     /// Returns the number of trailing zeros in the binary representation of
@@ -174,17 +195,22 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// Returns the number of ones in the binary representation of `self`.
     #[inline]
     #[must_use]
-    pub fn count_ones(&self) -> usize {
-        self.as_limbs()
-            .iter()
-            .map(|limb| limb.count_ones() as usize)
-            .sum()
+    pub const fn count_ones(&self) -> usize {
+        let mut total = 0;
+
+        let mut i = 0;
+        while i < LIMBS {
+            total += self.limbs[i].count_ones() as usize;
+            i += 1;
+        }
+
+        total
     }
 
     /// Returns the number of zeros in the binary representation of `self`.
     #[must_use]
     #[inline]
-    pub fn count_zeros(&self) -> usize {
+    pub const fn count_zeros(&self) -> usize {
         BITS - self.count_ones()
     }
 
@@ -194,7 +220,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// For the maximum length of the type, use [`Uint::BITS`](Self::BITS).
     #[must_use]
     #[inline]
-    pub fn bit_len(&self) -> usize {
+    pub const fn bit_len(&self) -> usize {
         BITS - self.leading_zeros()
     }
 
@@ -204,7 +230,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// For the maximum length of the type, use [`Uint::BYTES`](Self::BYTES).
     #[must_use]
     #[inline]
-    pub fn byte_len(&self) -> usize {
+    pub const fn byte_len(&self) -> usize {
         (self.bit_len() + 7) / 8
     }
 
@@ -425,15 +451,8 @@ impl<const BITS: usize, const LIMBS: usize> Not for Uint<BITS, LIMBS> {
     type Output = Self;
 
     #[inline]
-    fn not(mut self) -> Self::Output {
-        if BITS == 0 {
-            return Self::ZERO;
-        }
-        for limb in &mut self.limbs {
-            *limb = u64::not(*limb);
-        }
-        self.limbs[LIMBS - 1] &= Self::MASK;
-        self
+    fn not(self) -> Self::Output {
+        Self::not(self)
     }
 }
 

--- a/src/special.rs
+++ b/src/special.rs
@@ -19,7 +19,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// Returns `true` if and only if `self == 2^k` for some `k`.
     #[inline]
     #[must_use]
-    pub fn is_power_of_two(self) -> bool {
+    pub const fn is_power_of_two(self) -> bool {
         self.count_ones() == 1
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

Original motivation was to be able to call `byte_len()` in const context. But I added more const fn support because it was fun.

- Add const `not`
- Make `leading_zeros`, `leading_ones`, `count_ones`, `count_zeros`, `bit_len`, `byte_len`, `is_power_of_two` const

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Documentation
- [x] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
