### PR TITLE
perf: clean up div, cmp

### DIFF
--- a/src/algorithms/div/mod.rs
+++ b/src/algorithms/div/mod.rs
@@ -47,27 +47,22 @@ use crate::algorithms::DoubleWord;
 #[inline]
 pub fn div(numerator: &mut [u64], divisor: &mut [u64]) {
     // Trim most significant zeros from divisor.
-    let i = divisor
-        .iter()
-        .rposition(|&x| x != 0)
-        .expect("Divisor is zero");
-    let divisor = &mut divisor[..=i];
-    debug_assert!(!divisor.is_empty());
-    debug_assert!(divisor.last() != Some(&0));
+    let divisor = super::trim_end_zeros_mut(divisor);
+    assert!(!divisor.is_empty(), "divisor is 0");
+    debug_assert_ne!(*divisor.last().unwrap(), 0);
 
-    // Trim zeros from numerator
-    let numerator = if let Some(i) = numerator.iter().rposition(|&n| n != 0) {
-        &mut numerator[..=i]
-    } else {
-        // Empty numerator (q, r) = (0,0)
+    // Trim most significant zeros from numerator.
+    let numerator = super::trim_end_zeros_mut(numerator);
+    if numerator.is_empty() {
+        // Empty numerator: (q, r) = (0, 0)
         divisor.fill(0);
         return;
-    };
-    debug_assert!(!numerator.is_empty());
-    debug_assert!(*numerator.last().unwrap() != 0);
+    }
+    debug_assert_ne!(*numerator.last().unwrap(), 0);
 
-    // If numerator is smaller than divisor (q, r) = (0, numerator)
+    // if super::cmp(numerator, divisor).is_lt() {
     if numerator.len() < divisor.len() {
+        // Numerator is smaller than the divisor: (q, r) = (0, numerator)
         let (remainder, padding) = divisor.split_at_mut(numerator.len());
         remainder.copy_from_slice(numerator);
         padding.fill(0);

--- a/src/algorithms/div/mod.rs
+++ b/src/algorithms/div/mod.rs
@@ -64,14 +64,7 @@ pub fn div(numerator: &mut [u64], divisor: &mut [u64]) {
     }
     debug_assert_ne!(*numerator.last().unwrap(), 0);
 
-    // Compare length first, as we have trimmed zeros.
-    // let is_less = match numerator.len().cmp(&divisor.len()) {
-    //     core::cmp::Ordering::Less => true,
-    //     core::cmp::Ordering::Equal => super::cmp(numerator, divisor).is_lt(),
-    //     core::cmp::Ordering::Greater => false,
-    // };
-    let is_less = numerator.len() < divisor.len();
-    if is_less {
+    if super::cmp(numerator, divisor).is_lt() {
         // Numerator is smaller than the divisor: (q, r) = (0, numerator)
         let (remainder, padding) = divisor.split_at_mut(numerator.len());
         remainder.copy_from_slice(numerator);

--- a/src/algorithms/div/small.rs
+++ b/src/algorithms/div/small.rs
@@ -14,6 +14,14 @@ use crate::{algorithms::DoubleWord, utils::unlikely};
 // [`div_2x1_ref`].
 pub use self::{div_2x1_mg10 as div_2x1, div_3x2_mg10 as div_3x2};
 
+/// ⚠️ Compute single limb division.
+#[inline(always)]
+#[track_caller]
+#[must_use]
+pub const fn div_1x1(numerator: u64, divisor: u64) -> (u64, u64) {
+    (numerator / divisor, numerator % divisor)
+}
+
 /// ⚠️ Compute single limb normalized division.
 ///
 /// The divisor must be normalized. See algorithm 7 from [MG10].

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -87,7 +87,7 @@ impl DoubleWord<u64> for u128 {
 }
 
 /// Compare two `u64` slices in reverse order.
-#[inline]
+#[inline(always)]
 #[must_use]
 pub fn cmp(left: &[u64], right: &[u64]) -> Ordering {
     let l = core::cmp::min(left.len(), right.len());

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -86,33 +86,33 @@ impl DoubleWord<u64> for u128 {
     }
 }
 
-/// Compare two `u64` slices in reverse order.
+/// Compare two limb slices in reverse order.
+///
+/// Assumes that if the slices are of different length, the longer slice is
+/// always greater than the shorter slice.
 #[inline(always)]
 #[must_use]
-pub fn cmp(left: &[u64], right: &[u64]) -> Ordering {
-    let l = core::cmp::min(left.len(), right.len());
-
-    // Slice to the loop iteration range to enable bound check
-    // elimination in the compiler
-    let lhs = &left[..l];
-    let rhs = &right[..l];
-
-    for i in (0..l).rev() {
-        match i8::from(lhs[i] > rhs[i]) - i8::from(lhs[i] < rhs[i]) {
+pub fn cmp(a: &[u64], b: &[u64]) -> Ordering {
+    match a.len().cmp(&b.len()) {
+        Ordering::Equal => {}
+        non_eq => return non_eq,
+    }
+    for i in (0..a.len()).rev() {
+        match i8::from(a[i] > b[i]) - i8::from(a[i] < b[i]) {
             -1 => return Ordering::Less,
             0 => {}
             1 => return Ordering::Greater,
             _ => unsafe { core::hint::unreachable_unchecked() },
         }
 
-        // Equivalent to:
-        // match lhs[i].cmp(&rhs[i]) {
+        // Equivalent to the following code, but on older rustc versions
+        // performs better:
+        // match a[i].cmp(&b[i]) {
         //     Ordering::Equal => {}
         //     non_eq => return non_eq,
         // }
     }
-
-    left.len().cmp(&right.len())
+    Ordering::Equal
 }
 
 // Helper while [Rust#85532](https://github.com/rust-lang/rust/issues/85532) stabilizes.

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -87,7 +87,7 @@ impl DoubleWord<u64> for u128 {
 }
 
 /// Compare two `u64` slices in reverse order.
-#[inline(always)]
+#[inline]
 #[must_use]
 pub fn cmp(left: &[u64], right: &[u64]) -> Ordering {
     let l = core::cmp::min(left.len(), right.len());
@@ -131,4 +131,20 @@ pub const fn borrowing_sub(lhs: u64, rhs: u64, borrow: bool) -> (u64, bool) {
     let (result, borrow_1) = lhs.overflowing_sub(rhs);
     let (result, borrow_2) = result.overflowing_sub(borrow as u64);
     (result, borrow_1 | borrow_2)
+}
+
+#[inline]
+pub(crate) const fn trim_end_zeros(mut x: &[u64]) -> &[u64] {
+    while let [rest @ .., 0] = x {
+        x = rest;
+    }
+    x
+}
+
+#[inline]
+pub(crate) fn trim_end_zeros_mut(mut x: &mut [u64]) -> &mut [u64] {
+    while let [rest @ .., 0] = x {
+        x = rest;
+    }
+    x
 }

--- a/src/algorithms/mul.rs
+++ b/src/algorithms/mul.rs
@@ -31,8 +31,9 @@ pub fn addmul(mut lhs: &mut [u64], mut a: &[u64], mut b: &[u64]) -> bool {
             lhs = rest;
         }
     }
-    while let [rest @ .., 0] = a {
-        a = rest;
+    a = super::trim_end_zeros(a);
+    if a.is_empty() {
+        return false;
     }
 
     // Trim zeros from `b`
@@ -42,13 +43,11 @@ pub fn addmul(mut lhs: &mut [u64], mut a: &[u64], mut b: &[u64]) -> bool {
             lhs = rest;
         }
     }
-    while let [rest @ .., 0] = b {
-        b = rest;
-    }
-
-    if a.is_empty() || b.is_empty() {
+    b = super::trim_end_zeros(b);
+    if b.is_empty() {
         return false;
     }
+
     if lhs.is_empty() {
         return true;
     }

--- a/src/div.rs
+++ b/src/div.rs
@@ -50,7 +50,13 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     #[must_use]
     #[track_caller]
     pub fn div_rem(mut self, mut rhs: Self) -> (Self, Self) {
-        algorithms::div(&mut self.limbs, &mut rhs.limbs);
+        if LIMBS == 1 {
+            let q = &mut self.limbs[0];
+            let r = &mut rhs.limbs[0];
+            (*q, *r) = algorithms::div::div_1x1(*q, *r);
+        } else {
+            algorithms::div(&mut self.limbs, &mut rhs.limbs);
+        }
         (self, rhs)
     }
 


### PR DESCRIPTION
- Remove impossible panics and reduce size of possible panics (div by 0) from div dispatching code to make it more amenable for inlining
- Fix cmp for slices of different lengths; improve comments