### PR TITLE
chore: improve const-for usability

### DIFF
--- a/src/algorithms/mul_redc.rs
+++ b/src/algorithms/mul_redc.rs
@@ -218,7 +218,7 @@ mod test {
 
     #[test]
     fn test_mul_redc() {
-        const_for!(BITS in NON_ZERO if (BITS >= 16) {
+        const_for!(BITS in NON_ZERO if BITS >= 16 {
             const LIMBS: usize = nlimbs(BITS);
             type U = Uint<BITS, LIMBS>;
             proptest!(|(mut a: U, mut b: U, mut m: U)| {
@@ -240,7 +240,7 @@ mod test {
 
     #[test]
     fn test_square_redc() {
-        const_for!(BITS in NON_ZERO if (BITS >= 16) {
+        const_for!(BITS in NON_ZERO if BITS >= 16 {
             const LIMBS: usize = nlimbs(BITS);
             type U = Uint<BITS, LIMBS>;
             proptest!(|(mut a: U, mut m: U)| {

--- a/src/const_for.rs
+++ b/src/const_for.rs
@@ -42,7 +42,7 @@
 /// ```
 #[macro_export]
 macro_rules! const_for {
-    ($C:ident in [ $( $n:literal ),* ] $x:block) => {
+    ($C:ident in [$($n:expr),*] $x:block) => {
         $({
             const $C: usize = $n;
             $x
@@ -58,11 +58,9 @@ macro_rules! const_for {
     ($C:ident in BENCH $x:block) => {
         $crate::const_for!($C in [0, 64, 128, 192, 256, 384, 512, 4096] $x);
     };
-    ($C:ident in $S:ident if ( $c:expr ) $x:block) => {
+    ($C:ident in $S:tt if $($t:tt)*) => {
         $crate::const_for!($C in $S {
-            if $c {
-                $x
-            }
+            if $($t)*
         });
     };
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -189,7 +189,7 @@ mod tests {
 
     #[test]
     fn test_pow_log() {
-        const_for!(BITS in NON_ZERO if (BITS >= 64) {
+        const_for!(BITS in NON_ZERO if BITS >= 64 {
             const LIMBS: usize = nlimbs(BITS);
             type U = Uint<BITS, LIMBS>;
             proptest!(|(b in 2_u64..100, e in 0..BITS)| {
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn test_log_pow() {
-        const_for!(BITS in NON_ZERO if (BITS >= 64) {
+        const_for!(BITS in NON_ZERO if BITS >= 64 {
             const LIMBS: usize = nlimbs(BITS);
             type U = Uint<BITS, LIMBS>;
             proptest!(|(b in 2_u64..100, n: U)| {

--- a/src/modular.rs
+++ b/src/modular.rs
@@ -289,7 +289,7 @@ mod tests {
 
     #[test]
     fn test_mul_redc() {
-        const_for!(BITS in NON_ZERO if (BITS >= 16) {
+        const_for!(BITS in NON_ZERO if BITS >= 16 {
             const LIMBS: usize = nlimbs(BITS);
             type U = Uint<BITS, LIMBS>;
             proptest!(|(a: U, b: U, m: U)| {
@@ -312,7 +312,7 @@ mod tests {
 
     #[test]
     fn test_square_redc() {
-        const_for!(BITS in NON_ZERO if (BITS >= 16) {
+        const_for!(BITS in NON_ZERO if BITS >= 16 {
             const LIMBS: usize = nlimbs(BITS);
             type U = Uint<BITS, LIMBS>;
             proptest!(|(a: U, m: U)| {

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -186,7 +186,7 @@ mod tests {
 
     #[test]
     fn test_pow2_shl() {
-        const_for!(BITS in NON_ZERO if (BITS >= 2) {
+        const_for!(BITS in NON_ZERO if BITS >= 2 {
             const LIMBS: usize = nlimbs(BITS);
             type U = Uint<BITS, LIMBS>;
             proptest!(|(e in 0..=BITS+1)| {
@@ -197,7 +197,7 @@ mod tests {
 
     #[test]
     fn test_pow_product() {
-        const_for!(BITS in NON_ZERO if (BITS >= 64) {
+        const_for!(BITS in NON_ZERO if BITS >= 64 {
             const LIMBS: usize = nlimbs(BITS);
             type U = Uint<BITS, LIMBS>;
             proptest!(|(b in 2_u64..100, e in 0_usize..100)| {

--- a/src/root.rs
+++ b/src/root.rs
@@ -99,7 +99,7 @@ mod tests {
     #[test]
     #[allow(clippy::absurd_extreme_comparisons)] // From macro.
     fn test_root() {
-        const_for!(BITS in SIZES if (BITS > 3) {
+        const_for!(BITS in SIZES if BITS > 3 {
             const LIMBS: usize = nlimbs(BITS);
             type U = Uint<BITS, LIMBS>;
             proptest!(|(value: U, degree in 1_usize..=5)| {
@@ -120,7 +120,7 @@ mod tests {
     #[allow(clippy::absurd_extreme_comparisons)] // From macro.
     #[allow(clippy::reversed_empty_ranges)] // From macro.
     fn test_root_large() {
-        const_for!(BITS in SIZES if (BITS > 3) {
+        const_for!(BITS in SIZES if BITS > 3 {
             const LIMBS: usize = nlimbs(BITS);
             type U = Uint<BITS, LIMBS>;
             proptest!(|(value: U, degree in 1_usize..=BITS)| {


### PR DESCRIPTION
- allow arbitrary expressions
- allow `if` usage with any of the other variants, not just with identifiers