### PR TITLE
perf: make add_mod faster using overflow check

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -75,7 +75,6 @@ macro_rules! impl_bin_op {
     };
 }
 
-#[allow(unused)]
 macro_rules! assume {
     ($e:expr $(,)?) => {
         if !$e {
@@ -90,7 +89,6 @@ macro_rules! assume {
     };
 }
 
-#[allow(unused)]
 macro_rules! debug_unreachable {
     ($($t:tt)*) => {
         if cfg!(debug_assertions) {
@@ -98,6 +96,21 @@ macro_rules! debug_unreachable {
         } else {
             unsafe { core::hint::unreachable_unchecked() };
         }
+    };
+}
+
+/// `let $id = &mut [0u64; nlimbs(2 * BITS)][..]`
+macro_rules! let_double_bits {
+    ($id:ident) => {
+        // This array casting is a workaround for `generic_const_exprs` not being
+        // stable.
+        let mut double = [[0u64; 2]; LIMBS];
+        let double_len = crate::nlimbs(2 * BITS);
+        debug_assert!(2 * LIMBS >= double_len);
+        // SAFETY: `[[u64; 2]; LIMBS] == [u64; 2 * LIMBS] >= [u64; nlimbs(2 * BITS)]`.
+        let $id = unsafe {
+            core::slice::from_raw_parts_mut(double.as_mut_ptr().cast::<u64>(), double_len)
+        };
     };
 }
 

--- a/src/modular.rs
+++ b/src/modular.rs
@@ -36,8 +36,8 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
             return Self::ZERO;
         }
 
-        // This is not going to truncate with the final cast because the modulus value is 64
-        // bits.
+        // This is not going to truncate with the final cast because the modulus value
+        // is 64 bits.
         #[allow(clippy::cast_possible_truncation)]
         if BITS <= 64 {
             self.limbs[0] =

--- a/src/modular.rs
+++ b/src/modular.rs
@@ -36,6 +36,9 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
             return Self::ZERO;
         }
 
+        // This is not going to truncate with the final cast because the modulus value is 64
+        // bits.
+        #[allow(clippy::cast_possible_truncation)]
         if BITS <= 64 {
             self.limbs[0] =
                 ((self.limbs[0] as u128 + rhs.limbs[0] as u128) % modulus.limbs[0] as u128) as u64;

--- a/src/modular.rs
+++ b/src/modular.rs
@@ -7,6 +7,21 @@ use crate::{algorithms, Uint};
 // See also <https://static1.squarespace.com/static/61f7cacf2d7af938cad5b81c/t/62deb4e0c434f7134c2730ee/1658762465114/modular_multiplication.pdf>
 // FEATURE: Modular wrapper class, like Wrapping.
 
+/// `let $id = &mut [0u64; nlimbs(2 * BITS)][..]`
+macro_rules! let_double_bits {
+    ($id:ident) => {
+        // This array casting is a workaround for `generic_const_exprs` not being
+        // stable.
+        let mut double = [[0u64; 2]; LIMBS];
+        let double_len = crate::nlimbs(2 * BITS);
+        debug_assert!(2 * LIMBS >= double_len);
+        // SAFETY: `[[u64; 2]; LIMBS] == [u64; 2 * LIMBS] >= [u64; nlimbs(2 * BITS)]`.
+        let $id = unsafe {
+            core::slice::from_raw_parts_mut(double.as_mut_ptr().cast::<u64>(), double_len)
+        };
+    };
+}
+
 impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// ⚠️ Compute $\mod{\mathtt{self}}_{\mathtt{modulus}}$.
     ///
@@ -48,32 +63,12 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         // do overflowing add, then check if we should divrem
         let (result, overflow) = self.overflowing_add(rhs);
         if overflow {
-            // Allocate at least `nlimbs(2 * BITS)` limbs to store the numerator. This array
-            // casting is a workaround for `generic_const_exprs` not being stable.
-            let mut numerator = [[0u64; 2]; LIMBS];
-            let numerator_len = crate::nlimbs(2 * BITS);
-            debug_assert!(2 * LIMBS >= numerator_len);
-            // SAFETY: `[[u64; 2]; LIMBS] == [u64; 2 * LIMBS] >= [u64; nlimbs(2 * BITS)]`.
-            let numerator = unsafe {
-                core::slice::from_raw_parts_mut(numerator.as_mut_ptr().cast::<u64>(), numerator_len)
-            };
-
-            // Copy the result limbs into the numerator.
-            // SAFETY:
-            // * `result` is valid for the length of `result.limbs`
-            // * `numerator` is valid for the length of `result.limbs`
-            // * `result` and `numerator` do not overlap
-            unsafe {
-                core::ptr::copy_nonoverlapping(
-                    result.as_limbs().as_ptr(),
-                    numerator.as_mut_ptr(),
-                    result.limbs.len(),
-                );
-            };
-
-            // Now we have to fill in the carry bit before reducing.
-            let (limbs, bits) = (BITS / 64, BITS % 64);
-            numerator[limbs] |= 1 << bits;
+            // Add carry bit to the result in an extra limb.
+            let_double_bits!(numerator);
+            let numerator = &mut numerator[..=LIMBS];
+            numerator[..LIMBS].copy_from_slice(result.as_limbs());
+            let (limb, bit) = (BITS / 64, BITS % 64);
+            numerator[limb] |= 1 << bit;
 
             // Compute modulus using `div_rem`.
             // This stores the remainder in the divisor, `modulus`.
@@ -98,17 +93,8 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
             return Self::ZERO;
         }
 
-        // Allocate at least `nlimbs(2 * BITS)` limbs to store the product. This array
-        // casting is a workaround for `generic_const_exprs` not being stable.
-        let mut product = [[0u64; 2]; LIMBS];
-        let product_len = crate::nlimbs(2 * BITS);
-        debug_assert!(2 * LIMBS >= product_len);
-        // SAFETY: `[[u64; 2]; LIMBS] == [u64; 2 * LIMBS] >= [u64; nlimbs(2 * BITS)]`.
-        let product = unsafe {
-            core::slice::from_raw_parts_mut(product.as_mut_ptr().cast::<u64>(), product_len)
-        };
-
         // Compute full product.
+        let_double_bits!(product);
         let overflow = algorithms::addmul(product, self.as_limbs(), rhs.as_limbs());
         debug_assert!(!overflow);
 


### PR DESCRIPTION
Rebase of https://github.com/recmo/uint/pull/458 by @Rjected.

Original description:

---

## Motivation

I noticed that nethermind's addmod implementation was faster than ours, and implemented differently.
## Solution

I implemented a version similar to the nethermind implementation that first does an overflowing add, then calculates the remainder. If we did not overflow, reduction is done normally. Otherwise, the remainder calculation is done on a larger number of limbs.

Unfortunately we can't easily make an array of `BITS + 1` or `LIMBS + 1`, which would be much easier, maybe there's some hack we can do.

Geth's implementation seems faster (from [gas-cost-estimator](https://github.com/imapp-pl/gas-cost-estimator/blob/master/docs/report_stage_iv.md) benchmarks), impl is here: https://github.com/holiman/uint256/blob/a17fcfb6f8b0245533928fa96aace2cd4c2e9b18/uint256.go#L217-L283

I implemented this and generalized it here: https://github.com/recmo/uint/compare/main...Rjected:uint:add-mod-complex-2?expand=1

But this did not seem to be that much faster, although maybe it does make a difference for certain input types. Minimizing divisions in general seems useful.

Benchmarks:

```
     Running benches/bench.rs (target/release/deps/bench_uint-4a47e724b3087a0d)
Gnuplot not found, using plotters backend
add_mod/0               time:   [322.97 ps 325.55 ps 328.88 ps]
                        change: [-0.2202% +0.7018% +1.6081%] (p = 0.15 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

add_mod/64              time:   [8.0144 ns 8.1543 ns 8.3347 ns]
                        change: [-31.136% -28.116% -25.118%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

add_mod/128             time:   [36.795 ns 37.009 ns 37.221 ns]
                        change: [-34.917% -30.733% -27.106%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

add_mod/192             time:   [46.559 ns 46.919 ns 47.278 ns]
                        change: [-33.779% -26.132% -20.070%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

add_mod/256             time:   [51.080 ns 51.548 ns 52.058 ns]
                        change: [-24.502% -21.477% -18.755%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

add_mod/384             time:   [57.409 ns 58.555 ns 60.167 ns]
                        change: [-64.877% -44.614% -18.600%] (p = 0.04 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe

add_mod/512             time:   [72.986 ns 73.683 ns 74.375 ns]
                        change: [-16.333% -7.2151% +5.4801%] (p = 0.25 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

add_mod/4096            time:   [421.98 ns 436.19 ns 459.55 ns]
                        change: [-16.226% -0.5924% +22.105%] (p = 0.96 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) high mild
  6 (6.00%) high severe
```