### PR TITLE
feat: add shift benchmarks

### DIFF
--- a/benches/benches/bits.rs
+++ b/benches/benches/bits.rs
@@ -1,0 +1,8 @@
+use crate::prelude::*;
+
+pub fn group(criterion: &mut Criterion) {
+    const_for!(BITS in BENCH {
+        const LIMBS: usize = nlimbs(BITS);
+        bench_shifting_binop::<BITS, LIMBS, _>(criterion, "overflowing_shl", |a, b| a.overflowing_shl(b));
+    });
+}

--- a/benches/benches/bits.rs
+++ b/benches/benches/bits.rs
@@ -6,5 +6,14 @@ pub fn group(criterion: &mut Criterion) {
         bench_arbitrary_with(criterion, "overflowing_shl", (Uint::<BITS, LIMBS>::arbitrary(), 0..=BITS), move |(a, b)| {
             a.overflowing_shl(b)
         });
+        bench_arbitrary_with(criterion, "overflowing_shr", (Uint::<BITS, LIMBS>::arbitrary(), 0..=BITS), move |(a, b)| {
+            a.overflowing_shr(b)
+        });
+        bench_arbitrary_with(criterion, "wrapping_shl", (Uint::<BITS, LIMBS>::arbitrary(), 0..=BITS), move |(a, b)| {
+            a.wrapping_shl(b)
+        });
+        bench_arbitrary_with(criterion, "wrapping_shr", (Uint::<BITS, LIMBS>::arbitrary(), 0..=BITS), move |(a, b)| {
+            a.wrapping_shr(b)
+        });
     });
 }

--- a/benches/benches/bits.rs
+++ b/benches/benches/bits.rs
@@ -3,6 +3,8 @@ use crate::prelude::*;
 pub fn group(criterion: &mut Criterion) {
     const_for!(BITS in BENCH {
         const LIMBS: usize = nlimbs(BITS);
-        bench_shifting_binop::<BITS, LIMBS, _>(criterion, "overflowing_shl", |a, b| a.overflowing_shl(b));
+        bench_arbitrary_with(criterion, "overflowing_shl", (Uint::<BITS, LIMBS>::arbitrary(), 0..=BITS), move |(a, b)| {
+            a.overflowing_shl(b)
+        });
     });
 }

--- a/benches/benches/mod.rs
+++ b/benches/benches/mod.rs
@@ -1,5 +1,6 @@
 mod add;
 mod algorithms;
+mod bits;
 mod cmp;
 mod div;
 mod log;
@@ -20,4 +21,5 @@ pub fn group(c: &mut criterion::Criterion) {
     root::group(c);
     modular::group(c);
     algorithms::group(c);
+    bits::group(c);
 }

--- a/benches/benches/mod.rs
+++ b/benches/benches/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod prelude;
 
 pub fn group(c: &mut criterion::Criterion) {
     cmp::group(c);
+    bits::group(c);
     add::group(c);
     mul::group(c);
     div::group(c);
@@ -21,5 +22,4 @@ pub fn group(c: &mut criterion::Criterion) {
     root::group(c);
     modular::group(c);
     algorithms::group(c);
-    bits::group(c);
 }

--- a/benches/benches/prelude.rs
+++ b/benches/benches/prelude.rs
@@ -45,55 +45,6 @@ pub fn bench_ternary<const BITS: usize, const LIMBS: usize, U>(
     );
 }
 
-pub fn bench_shifting_binop<const BITS: usize, const LIMBS: usize, U>(
-    criterion: &mut criterion::Criterion,
-    name: &str,
-    mut f: impl FnMut(Uint<BITS, LIMBS>, usize) -> U,
-) {
-    bench_arbitrary_shifting::<Uint<BITS, LIMBS>, U>(
-        criterion,
-        &format!("{name}/{BITS}"),
-        0..=BITS,
-        move |(a, b)| f(a, b),
-    );
-}
-
-pub fn bench_arbitrary_shifting<T, U>(
-    criterion: &mut criterion::Criterion,
-    name: &str,
-    range: RangeInclusive<usize>,
-    f: impl FnMut((<T::Strategy as proptest::strategy::Strategy>::Value, usize)) -> U,
-) where
-    T: Arbitrary,
-{
-    bench_arbitrary_with_range(criterion, name, T::arbitrary(), range, f)
-}
-
-pub fn bench_arbitrary_with_range<T, U>(
-    criterion: &mut criterion::Criterion,
-    name: &str,
-    input: T,
-    range: RangeInclusive<usize>,
-    mut f: impl FnMut((T::Value, usize)) -> U,
-) where
-    T: Strategy,
-{
-    let mut runner = TestRunner::deterministic();
-
-    // create strategy that picks a value from the range
-    let (start, end) = range.into_inner();
-    let mut strategy = move || {
-        (
-            input.new_tree(&mut runner).unwrap().current(),
-            sample_uniform_incl(&mut runner, start, end),
-        )
-    };
-
-    criterion.bench_function(name, move |bencher| {
-        bencher.iter_batched(&mut strategy, &mut f, BatchSize::SmallInput);
-    });
-}
-
 pub fn bench_arbitrary<T: Arbitrary, U>(
     criterion: &mut criterion::Criterion,
     name: &str,

--- a/benches/benches/prelude.rs
+++ b/benches/benches/prelude.rs
@@ -32,6 +32,18 @@ pub fn bench_binop<const BITS: usize, const LIMBS: usize, U>(
     );
 }
 
+pub fn bench_shifting_binop<const BITS: usize, const LIMBS: usize, U>(
+    criterion: &mut criterion::Criterion,
+    name: &str,
+    mut f: impl FnMut(Uint<BITS, LIMBS>, usize) -> U,
+) {
+    bench_arbitrary::<(Uint<BITS, LIMBS>, usize), U>(
+        criterion,
+        &format!("{name}/{BITS}"),
+        move |(a, b)| f(a, b),
+    );
+}
+
 pub fn bench_ternary<const BITS: usize, const LIMBS: usize, U>(
     criterion: &mut criterion::Criterion,
     name: &str,

--- a/benches/benches/prelude.rs
+++ b/benches/benches/prelude.rs
@@ -6,11 +6,12 @@ use std::cell::RefCell;
 pub use criterion::{BatchSize, Criterion};
 pub use proptest::{
     arbitrary::Arbitrary,
+    num::sample_uniform_incl,
     strategy::{Strategy, ValueTree},
     test_runner::TestRunner,
 };
 pub use ruint::{const_for, nlimbs, uint, Bits, Uint, UintTryFrom, UintTryTo};
-pub use std::hint::black_box;
+pub use std::{hint::black_box, ops::RangeInclusive};
 
 pub fn bench_unop<const BITS: usize, const LIMBS: usize, U>(
     criterion: &mut criterion::Criterion,
@@ -32,18 +33,6 @@ pub fn bench_binop<const BITS: usize, const LIMBS: usize, U>(
     );
 }
 
-pub fn bench_shifting_binop<const BITS: usize, const LIMBS: usize, U>(
-    criterion: &mut criterion::Criterion,
-    name: &str,
-    mut f: impl FnMut(Uint<BITS, LIMBS>, usize) -> U,
-) {
-    bench_arbitrary::<(Uint<BITS, LIMBS>, usize), U>(
-        criterion,
-        &format!("{name}/{BITS}"),
-        move |(a, b)| f(a, b),
-    );
-}
-
 pub fn bench_ternary<const BITS: usize, const LIMBS: usize, U>(
     criterion: &mut criterion::Criterion,
     name: &str,
@@ -54,6 +43,55 @@ pub fn bench_ternary<const BITS: usize, const LIMBS: usize, U>(
         &format!("{name}/{BITS}"),
         move |(a, b, c)| f(a, b, c),
     );
+}
+
+pub fn bench_shifting_binop<const BITS: usize, const LIMBS: usize, U>(
+    criterion: &mut criterion::Criterion,
+    name: &str,
+    mut f: impl FnMut(Uint<BITS, LIMBS>, usize) -> U,
+) {
+    bench_arbitrary_shifting::<Uint<BITS, LIMBS>, U>(
+        criterion,
+        &format!("{name}/{BITS}"),
+        0..=BITS,
+        move |(a, b)| f(a, b),
+    );
+}
+
+pub fn bench_arbitrary_shifting<T, U>(
+    criterion: &mut criterion::Criterion,
+    name: &str,
+    range: RangeInclusive<usize>,
+    f: impl FnMut((<T::Strategy as proptest::strategy::Strategy>::Value, usize)) -> U,
+) where
+    T: Arbitrary,
+{
+    bench_arbitrary_with_range(criterion, name, T::arbitrary(), range, f)
+}
+
+pub fn bench_arbitrary_with_range<T, U>(
+    criterion: &mut criterion::Criterion,
+    name: &str,
+    input: T,
+    range: RangeInclusive<usize>,
+    mut f: impl FnMut((T::Value, usize)) -> U,
+) where
+    T: Strategy,
+{
+    let mut runner = TestRunner::deterministic();
+
+    // create strategy that picks a value from the range
+    let (start, end) = range.into_inner();
+    let mut strategy = move || {
+        (
+            input.new_tree(&mut runner).unwrap().current(),
+            sample_uniform_incl(&mut runner, start, end),
+        )
+    };
+
+    criterion.bench_function(name, move |bencher| {
+        bencher.iter_batched(&mut strategy, &mut f, BatchSize::SmallInput);
+    });
 }
 
 pub fn bench_arbitrary<T: Arbitrary, U>(

--- a/benches/benches/prelude.rs
+++ b/benches/benches/prelude.rs
@@ -11,7 +11,7 @@ pub use proptest::{
     test_runner::TestRunner,
 };
 pub use ruint::{const_for, nlimbs, uint, Bits, Uint, UintTryFrom, UintTryTo};
-pub use std::{hint::black_box, ops::RangeInclusive};
+pub use std::hint::black_box;
 
 pub fn bench_unop<const BITS: usize, const LIMBS: usize, U>(
     criterion: &mut criterion::Criterion,


### PR DESCRIPTION
## Motivation

We don't have a bench for shift operations.

## Solution

Added a bench for `overflowing_shl`, `wrapping_shl`, `overflowing_shr`, `wrapping_shr`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
