### PR TITLE
Avoid allocations in fmt machinery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,6 @@ std = [
     "bytes?/std",
     "fastrlp-03?/std",
     "fastrlp-04?/std",
-    "fmt",
     "num-bigint?/std",
     "num-integer?/std",
     "num-traits?/std",
@@ -150,7 +149,6 @@ alloc = [
     "valuable?/alloc",
     "zeroize?/alloc",
 ]
-fmt = []
 
 # nightly-only features
 nightly = []

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::missing_inline_in_public_items)] // allow format functions
-#![cfg(feature = "fmt")]
 
 use crate::Uint;
 use core::{


### PR DESCRIPTION
But still keep it under (different) feature flag

## Motivation

Use of formatting in no_std environments (or environments where `Global` allocator is not desired)

## Solution

Use stack-allocated buffer instead, with clear upper bound on number of possible limbs used for formatting

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog

