### PR TITLE
feat: remove "alloc" feature requirement from base_convert/fmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `bigdecimal` support ([#486])
 - `PartialEq` and `PartialOrd` implementations for primitive integers; minor breaking change for type inference ([#491])
 
+### Changed
+
+- `to_base_be` and `core::fmt` trait implementations are available without the "alloc" feature ([#488])
+
 ### Fixed
 
 - Check limb overflow in shift ops ([#476])
@@ -22,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#476]: https://github.com/recmo/uint/pull/476
 [#483]: https://github.com/recmo/uint/pull/483
 [#486]: https://github.com/recmo/uint/pull/486
+[#488]: https://github.com/recmo/uint/pull/488
 [#491]: https://github.com/recmo/uint/pull/491
 
 ## [1.15.0] - 2025-05-22


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

Alternative to https://github.com/recmo/uint/pull/478 by making to_base_be not allocate directly.
Closes #478.

~~Needs https://github.com/recmo/uint/pull/487 to gauge perf impact.~~

Closes https://github.com/recmo/uint/issues/294.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
