### PR TITLE
perf: specialize and use subtraction to implement PartialOrd

### DIFF
--- a/src/algorithms/cmp.rs
+++ b/src/algorithms/cmp.rs
@@ -1,0 +1,102 @@
+use super::borrowing_sub;
+use core::cmp::Ordering;
+
+/// Compare two limb slices in reverse order.
+///
+/// Assumes that if the slices are of different length, the longer slice is
+/// always greater than the shorter slice.
+#[inline(always)]
+#[must_use]
+pub fn cmp(a: &[u64], b: &[u64]) -> Ordering {
+    match a.len().cmp(&b.len()) {
+        Ordering::Equal => {}
+        non_eq => return non_eq,
+    }
+    for i in (0..a.len()).rev() {
+        match i8::from(a[i] > b[i]) - i8::from(a[i] < b[i]) {
+            -1 => return Ordering::Less,
+            0 => {}
+            1 => return Ordering::Greater,
+            _ => unsafe { core::hint::unreachable_unchecked() },
+        }
+
+        // Equivalent to the following code, but on older rustc versions
+        // performs better:
+        // match a[i].cmp(&b[i]) {
+        //     Ordering::Equal => {}
+        //     non_eq => return non_eq,
+        // }
+    }
+    Ordering::Equal
+}
+
+macro_rules! cmp_fns {
+    ($($name:ident, $op:literal => |$a:ident, $b:ident| $impl:expr),* $(,)?) => {
+        $(
+            /// Compare two limb slices in reverse order, returns `true` if
+            #[doc = concat!("`a ", $op, " b`.")]
+            ///
+            /// Assumes that if the slices are of different length, the longer slice is
+            /// always greater than the shorter slice.
+            #[inline(always)]
+            #[must_use]
+            pub fn $name($a: &[u64], $b: &[u64]) -> bool {
+                $impl
+            }
+        )*
+    };
+}
+
+cmp_fns! {
+    lt, "<"  => |a, b| match a.len().cmp(&b.len()) {
+        Ordering::Equal => lt_thru_sub(a, b),
+        non_eq => non_eq.is_lt(),
+    },
+    gt, ">"  => |a, b| lt(b, a),
+    ge, ">=" => |a, b| !lt(a, b),
+    le, "<=" => |a, b| !lt(b, a),
+}
+
+#[inline]
+fn lt_thru_sub(a: &[u64], b: &[u64]) -> bool {
+    assume!(a.len() == b.len());
+    let mut borrow = false;
+    let mut acc = 0;
+    for i in 0..a.len() {
+        let x;
+        (x, borrow) = borrowing_sub(a[i], b[i], borrow);
+        acc |= x;
+    }
+    unsafe { core::ptr::write_volatile(&mut acc, acc) };
+    borrow
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prop_assert_eq;
+
+    proptest::proptest! {
+        #[test]
+        fn test_cmp_u64(a: u64, b: u64) {
+            let x = &[a];
+            let y = &[b];
+            prop_assert_eq!(cmp(x, y), a.cmp(&b));
+            prop_assert_eq!(lt(x, y), a < b);
+            prop_assert_eq!(gt(x, y), a > b);
+            prop_assert_eq!(ge(x, y), a >= b);
+            prop_assert_eq!(le(x, y), a <= b);
+        }
+
+        #[test]
+        fn test_cmp_u128(a: u128, b: u128) {
+            let x = &[a as u64, (a >> 64) as u64];
+            let y = &[b as u64, (b >> 64) as u64];
+            prop_assert_eq!(cmp(x, y), a.cmp(&b));
+            prop_assert_eq!(lt(x, y), a < b);
+            prop_assert_eq!(gt(x, y), a > b);
+            prop_assert_eq!(ge(x, y), a >= b);
+            prop_assert_eq!(le(x, y), a <= b);
+        }
+    }
+}

--- a/src/algorithms/cmp.rs
+++ b/src/algorithms/cmp.rs
@@ -48,16 +48,18 @@ macro_rules! cmp_fns {
 }
 
 cmp_fns! {
-    lt, "<"  => |a, b| match a.len().cmp(&b.len()) {
-        Ordering::Equal => lt_thru_sub(a, b),
-        non_eq => non_eq.is_lt(),
-    },
+    // lt, "<"  => |a, b| match a.len().cmp(&b.len()) {
+    //     Ordering::Equal => lt_thru_sub(a, b),
+    //     non_eq => non_eq.is_lt(),
+    // },
+    lt, "<"  => |a, b| cmp(a, b).is_lt(),
     gt, ">"  => |a, b| lt(b, a),
     ge, ">=" => |a, b| !lt(a, b),
     le, "<=" => |a, b| !lt(b, a),
 }
 
 #[inline]
+#[allow(dead_code)]
 fn lt_thru_sub(a: &[u64], b: &[u64]) -> bool {
     assume!(a.len() == b.len());
     let mut borrow = false;

--- a/src/algorithms/div/knuth.rs
+++ b/src/algorithms/div/knuth.rs
@@ -194,8 +194,7 @@ pub fn div_nxm(numerator: &mut [u64], divisor: &mut [u64]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::algorithms::{addmul, cmp, sbb_n};
-    use core::cmp::Ordering;
+    use crate::algorithms::{addmul, lt, sbb_n};
     use proptest::{
         collection, num, proptest,
         strategy::{Just, Strategy},
@@ -317,7 +316,7 @@ mod tests {
             let d = divisor.clone();
             let remainder =
                 collection::vec(num::u64::ANY, divisor.len()).prop_map(move |mut vec| {
-                    if cmp(&vec, &d) != Ordering::Less {
+                    if !lt(&vec, &d) {
                         let carry = sbb_n(&mut vec, &d, 0);
                         assert_eq!(carry, 0);
                     }

--- a/src/algorithms/div/mod.rs
+++ b/src/algorithms/div/mod.rs
@@ -65,7 +65,7 @@ pub fn div(numerator: &mut [u64], divisor: &mut [u64]) {
     }
     debug_assert_ne!(*numerator.last().unwrap(), 0);
 
-    if super::cmp(numerator, divisor).is_lt() {
+    if super::lt(numerator, divisor) {
         // Numerator is smaller than the divisor: (q, r) = (0, numerator)
         let (remainder, padding) = divisor.split_at_mut(numerator.len());
         remainder.copy_from_slice(numerator);

--- a/src/algorithms/mul_redc.rs
+++ b/src/algorithms/mul_redc.rs
@@ -1,7 +1,7 @@
 // TODO: https://baincapitalcrypto.com/optimizing-montgomery-multiplication-in-webassembly/
 
-use super::{borrowing_sub, carrying_add, cmp};
-use core::{cmp::Ordering, iter::zip};
+use super::{borrowing_sub, carrying_add, lt};
+use core::iter::zip;
 
 /// Computes a * b * 2^(-BITS) mod modulus
 ///
@@ -11,8 +11,8 @@ use core::{cmp::Ordering, iter::zip};
 #[must_use]
 pub fn mul_redc<const N: usize>(a: [u64; N], b: [u64; N], modulus: [u64; N], inv: u64) -> [u64; N] {
     debug_assert_eq!(inv.wrapping_mul(modulus[0]), u64::MAX);
-    debug_assert_eq!(cmp(&a, &modulus), Ordering::Less);
-    debug_assert_eq!(cmp(&b, &modulus), Ordering::Less);
+    debug_assert!(lt(&a, &modulus));
+    debug_assert!(lt(&b, &modulus));
 
     // Coarsely Integrated Operand Scanning (CIOS)
     // See <https://www.microsoft.com/en-us/research/wp-content/uploads/1998/06/97Acar.pdf>
@@ -69,7 +69,7 @@ pub fn mul_redc<const N: usize>(a: [u64; N], b: [u64; N], modulus: [u64; N], inv
 #[allow(clippy::cast_possible_truncation)]
 pub fn square_redc<const N: usize>(a: [u64; N], modulus: [u64; N], inv: u64) -> [u64; N] {
     debug_assert_eq!(inv.wrapping_mul(modulus[0]), u64::MAX);
-    debug_assert_eq!(cmp(&a, &modulus), Ordering::Less);
+    debug_assert!(lt(&a, &modulus));
 
     let mut result = [0; N];
     let mut carry_outer = 0;

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -157,10 +157,10 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     pub const fn leading_zeros(&self) -> usize {
         let fixed = Self::MASK.leading_zeros() as usize;
 
-        as_primitives!(self, {
+        as_primitives!(self; {
             u64(x) => return x.leading_zeros() as usize - fixed,
             u128(x) => return x.leading_zeros() as usize - fixed,
-            u256(lo, hi) => return (if hi != 0 {
+            u256((lo, hi)) => return (if hi != 0 {
                 hi.leading_zeros()
             } else {
                 lo.leading_zeros() + 128

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -103,20 +103,32 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// Returns `true` if the value is zero.
     ///
     /// Note that this currently might perform worse than
-    /// [`is_zero`](Self::is_zero).
+    /// [`is_zero`](Self::is_zero), so prefer that if possible.
     #[inline]
     #[must_use]
     pub const fn const_is_zero(&self) -> bool {
+        as_primitives!(self; {
+            u64(x) => return x == 0,
+            u128(x) => return x == 0,
+            u256((lo, hi)) => return (lo | hi) == 0,
+        });
+
         self.const_eq(&Self::ZERO)
     }
 
     /// Returns `true` if `self` equals `other`.
     ///
     /// Note that this currently might perform worse than the derived
-    /// `PartialEq` (`==` operator).
+    /// `PartialEq` (`==` operator), so prefer that if possible.
     #[inline]
     #[must_use]
     pub const fn const_eq(&self, other: &Self) -> bool {
+        as_primitives!(self, other; {
+            u64(x, y) => return x == y,
+            u128(x, y) => return x == y,
+            u256((lo, hi), (lo2, hi2)) => return (lo == lo2) & (hi == hi2),
+        });
+
         // TODO: Replace with `self == other` and deprecate once `PartialEq` is const.
         let a = self.as_limbs();
         let b = other.as_limbs();

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -1,36 +1,29 @@
 use crate::{algorithms, Uint};
 use core::cmp::Ordering;
 
+macro_rules! cmp_fns {
+    ($($name:ident $op:tt),*) => {
+        $(
+            #[inline]
+            fn $name(&self, other: &Self) -> bool {
+                as_primitives!(self, other; {
+                    u64(x, y) => return x $op y,
+                    u128(x, y) => return x $op y,
+                });
+
+                algorithms::$name(self.as_limbs(), other.as_limbs())
+            }
+        )*
+    };
+}
+
 impl<const BITS: usize, const LIMBS: usize> PartialOrd for Uint<BITS, LIMBS> {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 
-    #[inline]
-    fn lt(&self, other: &Self) -> bool {
-        as_primitives!(self, other; {
-            u64(x, y) => return x < y,
-            u128(x, y) => return x < y,
-        });
-
-        algorithms::lt(self.as_limbs(), other.as_limbs())
-    }
-
-    #[inline]
-    fn gt(&self, other: &Self) -> bool {
-        other.lt(self)
-    }
-
-    #[inline]
-    fn ge(&self, other: &Self) -> bool {
-        !self.lt(other)
-    }
-
-    #[inline]
-    fn le(&self, other: &Self) -> bool {
-        !other.lt(self)
-    }
+    cmp_fns!(lt <, gt >, ge >=, le <=);
 }
 
 impl<const BITS: usize, const LIMBS: usize> Ord for Uint<BITS, LIMBS> {


### PR DESCRIPTION
Makes <, <=, >, >= operators branchless by delegating to `lt`, implemented with borrowing_sub chain (a - b produces the overflow boolean for free in the CPU flags)

Currently codegen for the operators is not optimal due to https://github.com/rust-lang/rust/issues/143517