### PR TITLE
feat: implement PartialEq, PartialOrd for primitive integers

### DIFF
--- a/src/pow.rs
+++ b/src/pow.rs
@@ -202,7 +202,7 @@ mod tests {
             type U = Uint<BITS, LIMBS>;
             proptest!(|(b in 2_u64..100, e in 0_usize..100)| {
                 let b = U::from(b);
-                let prod = repeat(b).take(e).product();
+                let prod = repeat(b).take(e).product::<U>();
                 assert_eq!(b.pow(U::from(e)), prod);
             });
         });

--- a/src/support/der.rs
+++ b/src/support/der.rs
@@ -232,7 +232,7 @@ mod tests {
                     proptest!(|(value: Uint<BITS, LIMBS>)| {
                         let serialized = value.to_der().unwrap();
                         let der = <$ty>::from_der(&serialized).unwrap();
-                        let deserialized = der.try_into().unwrap();
+                        let deserialized = Uint::<BITS, LIMBS>::try_from(der).unwrap();
                         assert_eq!(value, deserialized);
                     });
                 });

--- a/src/support/serde.rs
+++ b/src/support/serde.rs
@@ -171,12 +171,12 @@ mod tests {
             const LIMBS: usize = nlimbs(BITS);
             proptest!(|(value: Uint<BITS, LIMBS>)| {
                 let serialized = serde_json::to_string(&value).unwrap();
-                let deserialized = serde_json::from_str(&serialized).unwrap();
+                let deserialized = serde_json::from_str::<Uint<BITS, LIMBS>>(&serialized).unwrap();
                 assert_eq!(value, deserialized);
             });
             proptest!(|(value: Bits<BITS, LIMBS>)| {
                 let serialized = serde_json::to_string(&value).unwrap();
-                let deserialized = serde_json::from_str(&serialized).unwrap();
+                let deserialized = serde_json::from_str::<Bits<BITS, LIMBS>>(&serialized).unwrap();
                 assert_eq!(value, deserialized);
             });
         });
@@ -213,12 +213,12 @@ mod tests {
             const LIMBS: usize = nlimbs(BITS);
             proptest!(|(value: Uint<BITS, LIMBS>)| {
                 let serialized = bincode::serialize(&value).unwrap();
-                let deserialized = bincode::deserialize(&serialized[..]).unwrap();
+                let deserialized = bincode::deserialize::<Uint<BITS, LIMBS>>(&serialized[..]).unwrap();
                 assert_eq!(value, deserialized);
             });
             proptest!(|(value: Bits<BITS, LIMBS>)| {
                 let serialized = bincode::serialize(&value).unwrap();
-                let deserialized = bincode::deserialize(&serialized[..]).unwrap();
+                let deserialized = bincode::deserialize::<Bits<BITS, LIMBS>>(&serialized[..]).unwrap();
                 assert_eq!(value, deserialized);
             });
         });

--- a/src/support/ssz.rs
+++ b/src/support/ssz.rs
@@ -55,7 +55,7 @@ mod tests {
             proptest!(|(value: Uint<BITS, LIMBS>)| {
                 let expected = value;
                 let encoded = ssz::Encode::as_ssz_bytes(&expected);
-                let actual = ssz::Decode::from_ssz_bytes(&encoded).unwrap();
+                let actual: Uint<BITS, LIMBS> = ssz::Decode::from_ssz_bytes(&encoded).unwrap();
                 assert_eq!(expected, actual, "Failed for value: {value:?}" );
             });
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

This is a minor breaking change to inference as you can see from the changed tests. This is generally acceptable if it doesn't have that big of an impact in practice.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Implement `Partial{Eq,Ord}<$int> for Uint`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [x] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
