### PR TITLE
perf: roll mul_add_n

### DIFF
--- a/src/algorithms/div/mod.rs
+++ b/src/algorithms/div/mod.rs
@@ -45,6 +45,7 @@ use crate::algorithms::DoubleWord;
 ///
 /// Panics if `divisor` is zero.
 #[inline]
+#[cfg_attr(debug_assertions, track_caller)]
 pub fn div(numerator: &mut [u64], divisor: &mut [u64]) {
     // Trim most significant zeros from divisor.
     let divisor = super::trim_end_zeros_mut(divisor);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // Unstable features
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![cfg_attr(feature = "nightly", feature(core_intrinsics))]
+#![cfg_attr(feature = "nightly", feature(core_intrinsics, bigint_helper_methods))]
 #![cfg_attr(feature = "nightly", allow(internal_features))]
 #![cfg_attr(
     feature = "generic_const_exprs",

--- a/src/mul.rs
+++ b/src/mul.rs
@@ -39,7 +39,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     pub fn overflowing_mul(self, rhs: Self) -> (Self, bool) {
         let mut result = Self::ZERO;
         let mut overflow = algorithms::addmul(&mut result.limbs, self.as_limbs(), rhs.as_limbs());
-        if BITS > 0 {
+        if Self::SHOULD_MASK {
             overflow |= result.limbs[LIMBS - 1] > Self::MASK;
             result.apply_mask();
         }
@@ -63,7 +63,8 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     pub fn wrapping_mul(self, rhs: Self) -> Self {
         let mut result = Self::ZERO;
         algorithms::addmul_n(&mut result.limbs, self.as_limbs(), rhs.as_limbs());
-        result.masked()
+        result.apply_mask();
+        result
     }
 
     /// Computes the inverse modulo $2^{\mathtt{BITS}}$ of `self`, returning


### PR DESCRIPTION
We can roll back up the loop in add_mul_n which yields identical or better results for small lengths. For larger lengths (currently > 8) we fallback to the normal `addmul` because of the quadratic nature of the naive algorithm.

Supersedes https://github.com/recmo/uint/pull/474.
Closes #474.