### PR TITLE
perf: improve u128 conversions

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -130,13 +130,15 @@ macro_rules! as_primitives {
     };
     (@arm $uint:expr; u128($n:ident) => $e:expr) => {
         if LIMBS == 2 {
-            let $n = $uint.as_double_words()[0].0;
+            let $n = $uint.as_double_words()[0].get();
             $e
         }
     };
     (@arm $uint:expr; u256($lo:ident, $hi:ident) => $e:expr) => {
         if LIMBS == 4 {
-            let &[$crate::pu128($lo), $crate::pu128($hi)] = $uint.as_double_words() else { unreachable!() };
+            let &[lo, hi] = $uint.as_double_words() else { unreachable!() };
+            let $lo = lo.get();
+            let $hi = hi.get();
             $e
         }
     };


### PR DESCRIPTION
Plus a fix for `as_double_words` in big endian

Same as https://github.com/recmo/uint/pull/477 for u/i 128