### PR TITLE
perf: special case small integers in fmt

### DIFF
--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -39,8 +39,8 @@ macro_rules! impl_for_primitives {
                 #[inline]
                 #[allow(unused_comparisons)] // Both signed and unsigned integers use this.
                 #[allow(clippy::cast_possible_truncation)] // Unreachable.
-                fn partial_cmp(&self, other: &$t) -> Option<Ordering> {
-                    if *other < 0 {
+                fn partial_cmp(&self, &other: &$t) -> Option<Ordering> {
+                    if other < 0 {
                         return Some(Ordering::Greater);
                     }
 
@@ -48,12 +48,12 @@ macro_rules! impl_for_primitives {
                         let Ok(self_t) = u64::try_from(self) else {
                             return Some(Ordering::Greater);
                         };
-                        self_t.partial_cmp(&(*other as u64))
+                        self_t.partial_cmp(&(other as u64))
                     } else {
                         let Ok(self_t) = u128::try_from(self) else {
                             return Some(Ordering::Greater);
                         };
-                        self_t.partial_cmp(&(*other as u128))
+                        self_t.partial_cmp(&(other as u128))
                     }
                 }
             }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -55,6 +55,13 @@ macro_rules! impl_fmt {
     ($tr:path; $base:ty, $base_char:literal) => {
         impl<const BITS: usize, const LIMBS: usize> $tr for Uint<BITS, LIMBS> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                if let Ok(small) = u64::try_from(self) {
+                    return <u64 as $tr>::fmt(&small, f);
+                }
+                if let Ok(small) = u128::try_from(self) {
+                    return <u128 as $tr>::fmt(&small, f);
+                }
+
                 // Use `BITS` for all bases since `generic_const_exprs` is not yet stable.
                 let mut buffer = DisplayBuffer::<BITS>::new();
                 let mut first = true;


### PR DESCRIPTION
This is a very cheap check to avoid using `to_base_be` at all when the integer is small enough. It doesn't show any improvements in the benchmarks for >128 bits because the numbers are uniformly sampled, so they will always be at full bits, but it's a massive speed up as can be seen from the 64 and 128 bit benchmarks.

~~Based on #490.~~