### PR TITLE
perf: almost remove alloc from serde

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -56,11 +56,11 @@ macro_rules! impl_fmt {
         impl<const BITS: usize, const LIMBS: usize> $tr for Uint<BITS, LIMBS> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 // Use `BITS` for all bases since `generic_const_exprs` is not yet stable.
-                let mut buffer = DisplayBuffer::<BITS>::new();
+                let mut s = StackString::<BITS>::new();
                 let mut first = true;
                 for spigot in self.to_base_be_2(<$base>::MAX) {
                     write!(
-                        buffer,
+                        s,
                         concat!("{:0width$", $base_char, "}"),
                         spigot,
                         width = if first { 0 } else { <$base>::WIDTH },
@@ -68,7 +68,7 @@ macro_rules! impl_fmt {
                     .unwrap();
                     first = false;
                 }
-                f.pad_integral(true, <$base>::PREFIX, buffer.as_str())
+                f.pad_integral(true, <$base>::PREFIX, s.as_str())
             }
         }
     };
@@ -86,14 +86,15 @@ impl_fmt!(fmt::Octal; base::Octal, "o");
 impl_fmt!(fmt::LowerHex; base::Hexadecimal, "x");
 impl_fmt!(fmt::UpperHex; base::Hexadecimal, "X");
 
-struct DisplayBuffer<const SIZE: usize> {
+/// A stack-allocated buffer that implements [`fmt::Write`].
+pub(crate) struct StackString<const SIZE: usize> {
     len: usize,
     buf: [MaybeUninit<u8>; SIZE],
 }
 
-impl<const SIZE: usize> DisplayBuffer<SIZE> {
+impl<const SIZE: usize> StackString<SIZE> {
     #[inline]
-    const fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
             len: 0,
             buf: unsafe { MaybeUninit::uninit().assume_init() },
@@ -101,20 +102,20 @@ impl<const SIZE: usize> DisplayBuffer<SIZE> {
     }
 
     #[inline]
-    fn as_str(&self) -> &str {
+    pub(crate) const fn as_str(&self) -> &str {
         // SAFETY: `buf` is only written to by the `fmt::Write::write_str`
         // implementation which writes a valid UTF-8 string to `buf` and
         // correctly sets `len`.
-        unsafe { core::str::from_utf8_unchecked(&self.as_bytes_full()[..self.len]) }
+        unsafe { core::str::from_utf8_unchecked(self.as_bytes()) }
     }
 
     #[inline]
-    const unsafe fn as_bytes_full(&self) -> &[u8] {
-        unsafe { &*(self.buf.as_slice() as *const [_] as *const [u8]) }
+    const fn as_bytes(&self) -> &[u8] {
+        unsafe { core::slice::from_raw_parts(self.buf.as_ptr().cast(), self.len) }
     }
 }
 
-impl<const SIZE: usize> fmt::Write for DisplayBuffer<SIZE> {
+impl<const SIZE: usize> fmt::Write for StackString<SIZE> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         if self.len + s.len() > SIZE {
             return Err(fmt::Error);


### PR DESCRIPTION
Use the stack-allocated string to format instead of using heap-allocated `format!`/`String`