### PR TITLE
feat: add bincode 2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for [bincode 2](https://github.com/bincode-org/bincode) ([#516])
 - Introduce `ark-ff-05` feature flag for conversion to `ark-ff@0.5` types ([#526])
 
 ### Changed
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made `*next_power_of_two` and `*next_multiple_of` `const` ([#533])
 
 [#503]: https://github.com/recmo/uint/pull/503
+[#516]: https://github.com/recmo/uint/pull/516
 [#526]: https://github.com/recmo/uint/pull/526
 [#533]: https://github.com/recmo/uint/pull/533
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ ark-ff-03 = { version = "0.3.0", package = "ark-ff", optional = true, default-fe
 ark-ff-04 = { version = "0.4.0", package = "ark-ff", optional = true, default-features = false }
 ark-ff-05 = { version = "0.5.0", package = "ark-ff", optional = true, default-features = false }
 bigdecimal = { version = "0.4", optional = true, default-features = false }
+bincode-2 = { version = "2", package = "bincode", optional = true, default-features = false }
 bn-rs = { version = "0.2", optional = true, default-features = true }
 fastrlp-03 = { version = "0.3", package = "fastrlp", optional = true, default-features = false, features = [
     "alloc",
@@ -195,6 +196,7 @@ ark-ff = ["dep:ark-ff-03"]
 ark-ff-04 = ["dep:ark-ff-04"]
 ark-ff-05 = ["dep:ark-ff-05"]
 bigdecimal = ["dep:bigdecimal", "num-bigint"]
+bincode-2 = ["dep:bincode-2"]
 bn-rs = ["dep:bn-rs", "std"]
 borsh = ["dep:borsh"]
 bytemuck = ["dep:bytemuck"]

--- a/src/support/bincode_2.rs
+++ b/src/support/bincode_2.rs
@@ -1,0 +1,158 @@
+//! Support for the [`bincode`](https://crates.io/crates/bincode) crate.
+
+#![cfg(feature = "bincode-2")]
+#![cfg_attr(docsrs, doc(cfg(feature = "bincode-2")))]
+
+use crate::{Bits, Uint};
+use bincode_2::{
+    de::{read::Reader, BorrowDecode, BorrowDecoder, Decode, Decoder},
+    enc::{Encode, Encoder},
+    error::{DecodeError, EncodeError},
+};
+
+impl<const BITS: usize, const LIMBS: usize> Encode for Uint<BITS, LIMBS> {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        if BITS == 0 {
+            return Ok(());
+        }
+
+        #[cfg(target_endian = "little")]
+        return Encode::encode(self.as_le_slice(), encoder);
+
+        #[cfg(target_endian = "big")]
+        {
+            let mut limbs = self.limbs;
+            let mut i = 0;
+            while i < LIMBS {
+                limbs[i] = limbs[i].to_le();
+                i += 1;
+            }
+            // SAFETY: BYTES <= LIMBS * 8
+            let slice: &[u8] = unsafe {
+                let ptr = limbs.as_ptr() as *const u8;
+                core::slice::from_raw_parts(ptr, Self::BYTES)
+            };
+            Encode::encode(slice, encoder)
+        }
+    }
+}
+
+impl<Context, const BITS: usize, const LIMBS: usize> Decode<Context> for Uint<BITS, LIMBS> {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        if BITS == 0 {
+            return Ok(Self::ZERO);
+        }
+        let len = decode_slice_len(decoder)?;
+        if len != Self::BYTES {
+            return Err(DecodeError::ArrayLengthMismatch {
+                required: Self::BYTES,
+                found:    len,
+            });
+        }
+
+        decoder.claim_bytes_read(len)?;
+        let mut buffer = [0u64; LIMBS]; // not possible to use Self::BYTES or nbytes(BITS) here.
+        let slice = unsafe {
+            // SAFETY: We ensure that the buffer is large enough to hold the bytes
+            let ptr = buffer.as_mut_ptr().cast::<u8>();
+            core::slice::from_raw_parts_mut(ptr, Self::BYTES)
+        };
+        decoder.reader().read(slice)?;
+        Ok(Self::from_le_slice(&*slice))
+    }
+}
+
+impl<'de, Context, const BITS: usize, const LIMBS: usize> BorrowDecode<'de, Context>
+    for Uint<BITS, LIMBS>
+{
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
+        if BITS == 0 {
+            return Ok(Self::ZERO);
+        }
+        let bytes: &'de [u8] = BorrowDecode::borrow_decode(decoder)?;
+        if bytes.len() != Self::BYTES {
+            return Err(DecodeError::ArrayLengthMismatch {
+                required: Self::BYTES,
+                found:    bytes.len(),
+            });
+        }
+        Ok(Self::from_le_slice(bytes))
+    }
+}
+
+impl<const BITS: usize, const LIMBS: usize> Encode for Bits<BITS, LIMBS> {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        self.as_uint().encode(encoder)
+    }
+}
+
+impl<Context, const BITS: usize, const LIMBS: usize> Decode<Context> for Bits<BITS, LIMBS> {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        let uint: Uint<BITS, LIMBS> = Decode::decode(decoder)?;
+        Ok(Self::from(uint))
+    }
+}
+
+impl<'de, Context, const BITS: usize, const LIMBS: usize> BorrowDecode<'de, Context>
+    for Bits<BITS, LIMBS>
+{
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
+        let uint: Uint<BITS, LIMBS> = BorrowDecode::borrow_decode(decoder)?;
+        Ok(Self::from(uint))
+    }
+}
+
+/// Decodes the length of any slice, container, etc from the decoder
+#[inline]
+fn decode_slice_len<D: Decoder>(decoder: &mut D) -> Result<usize, DecodeError> {
+    let v = u64::decode(decoder)?;
+
+    v.try_into().map_err(|_| DecodeError::OutsideUsizeRange(v))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{const_for, nbytes, nlimbs};
+    use bincode_2::{
+        borrow_decode_from_slice, config::Config, decode_from_slice, encode_into_slice,
+    };
+    use proptest::proptest;
+
+    #[test]
+    fn test_bincode_2() {
+        test_bincode_2_inner(bincode_2::config::standard());
+        test_bincode_2_inner(bincode_2::config::legacy());
+    }
+
+    fn test_bincode_2_inner<C: Config>(config: C) {
+        const_for!(BITS in SIZES {
+            const LIMBS: usize = nlimbs(BITS);
+            const BUFFER_SIZE: usize = nbytes(BITS) + 8; // usize length takes at most 8 bytes
+            proptest!(|(value: Uint<BITS, LIMBS>)| {
+                let mut buffer = [0u8; BUFFER_SIZE];
+                let bytes_written = encode_into_slice(value, &mut buffer, config).unwrap();
+                let (deserialized, bytes_read) = decode_from_slice::<Uint<BITS, LIMBS>, _>(&buffer, config).unwrap();
+                assert_eq!(bytes_read, bytes_written);
+                assert_eq!(value, deserialized);
+                let (deserialized, bytes_read) = borrow_decode_from_slice::<Uint<BITS, LIMBS>, _>(&buffer, config).unwrap();
+                assert_eq!(bytes_read, bytes_written);
+                assert_eq!(value, deserialized);
+            });
+            proptest!(|(value: Bits<BITS, LIMBS>)| {
+                let mut buffer = [0u8; BUFFER_SIZE];
+                let bytes_written = encode_into_slice(value, &mut buffer, config).unwrap();
+                let (deserialized, bytes_read) = decode_from_slice::<Bits<BITS, LIMBS>, _>(&buffer, config).unwrap();
+                assert_eq!(bytes_read, bytes_written);
+                assert_eq!(value, deserialized);
+                let (deserialized, bytes_read) = borrow_decode_from_slice::<Bits<BITS, LIMBS>, _>(&buffer, config).unwrap();
+                assert_eq!(bytes_read, bytes_written);
+                assert_eq!(value, deserialized);
+            });
+        });
+    }
+}

--- a/src/support/mod.rs
+++ b/src/support/mod.rs
@@ -8,6 +8,7 @@ mod ark_ff;
 mod ark_ff_04;
 mod ark_ff_05;
 mod bigdecimal;
+mod bincode_2;
 mod bn_rs;
 mod borsh;
 mod bytemuck;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

[bincode 2](https://docs.rs/bincode/2.0.1/bincode/) is stable now, and [not compatible with serde](https://docs.rs/bincode/2.0.1/bincode/serde/index.html#known-issues).

Users might need those basic structs support bincode natively, so they can use `#[derive(bincode::Encode, bincode::Decode)]`.

## Solution

- Adds a `bincode-2` feature gate enables optional dependency `bincode` without default features.
- Adds `support::bincode_2` module with manually implemented alloc-free `Encode` and `Decode` traits for `Uint` and `Bits`

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
