### PR TITLE
Add Uint -> f64 conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MSRV bumped to 1.85 ([#503])
 - Made `*next_power_of_two` and `*next_multiple_of` `const` ([#533])
 - Reimplemented `TryFrom<f64>` for `Uint` to speed it up, fixing edge cases and removing `std` requirements ([#524])
+- Reimplemented `From<Uint>` for `f64` and `f32` to speed it up, fixing edge cases and removing `std` requirements ([#535])
 
 [#503]: https://github.com/recmo/uint/pull/503
 [#516]: https://github.com/recmo/uint/pull/516


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should (ideally) include tests.

The readme includes instructions for formatting, linting, building, testing and
building the documentation.
-->

## Motivation

Adds more conversions, completing #524 , allowing f64 <-> Uint conversions without the STD feature, hopefully speeding them up as well

## Solution

Again I used rust built-in code as an example as well as an article https://blog.m-ou.se/floats/

There are no benchmarks yet, I understand they need to get into the `main` branch first

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog

<!-- This template is based on https://github.com/tokio-rs/tokio/blob/tokio-1.13.0/.github/PULL_REQUEST_TEMPLATE.md and https://github.com/gakonst/ethers-rs/blob/0.5.3/.github/PULL_REQUEST_TEMPLATE.md -->
