### PR TITLE
Update primitive-types to v0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ parity-scale-codec = { version = "3", optional = true, default-features = false,
     "derive",
     "max-encoded-len",
 ] }
-primitive-types = { version = "0.12", optional = true, default-features = false }
+primitive-types = { version = "0.14", optional = true, default-features = false }
 proptest = { version = "1", optional = true, default-features = false, features = [
     "no_std",
 ] }


### PR DESCRIPTION
This pull request updates the version of the `primitive-types` dependency in `Cargo.toml` to improve compatibility and access to newer features.

Dependency updates:

## Motivation
* Upgraded `primitive-types` from version `0.12` to `0.14` in `Cargo.toml` to ensure the project uses the latest features and bug fixes.

The used version is obsoleted and causes the dependents to have multiple parallel 

## Solution
Bump the `primitive-types` dependency.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

