### PR TITLE
perf: extract last iteration on mul loop

### DIFF
--- a/src/algorithms/mul.rs
+++ b/src/algorithms/mul.rs
@@ -97,9 +97,16 @@ fn addmul_n_small(lhs: &mut [u64], a: &[u64], b: &[u64]) {
 
     for j in 0..n {
         let mut carry = 0;
-        for i in 0..(n - j) {
+        // Widening multiply-accumulate for all but the last position.
+        let i = n - j - 1;
+        for i in 0..i {
             (lhs[j + i], carry) = u128::muladd2(a[i], b[j], carry, lhs[j + i]).split();
         }
+        // Last position: the carry out is discarded (it would go beyond n
+        // limbs), so use truncated arithmetic to reduce register pressure.
+        lhs[j + i] = (a[i].wrapping_mul(b[j]))
+            .wrapping_add(lhs[j + i])
+            .wrapping_add(carry);
     }
 }
 


### PR DESCRIPTION
Extract the last iteration of the inner multiplication loop in `addmul_n_small` to use truncated arithmetic (`wrapping_mul` + `wrapping_add`) instead of widening `muladd2`. The carry out of the last position is always discarded, so the widening multiply is unnecessary and wastes register pressure.

This reduces stack spills in the generated assembly and brings the codegen closer to LLVM's native `mul i256` lowering.

`*a *= b` for `U256`, `-C target-cpu=native` (Zen 4):

| | Instructions | Stack accesses | mulx | imul |
|---|---|---|---|---|
| **Before** | 59 | 8 | 6 | 4 |
| **After** | 51 | 2 | 6 | 4 |
| **LLVM `mul i256`** | 51 | 0 | 6 | 4 |

`llvm-mca` on Zen 4 (`znver4`):

| | Instructions | uOps | Block RThroughput |
|---|---|---|---|
| **Before** | 59 | 65 | **15.7 cycles** |
| **After** | 51 | 57 | **12.7 cycles** |

19% throughput improvement from eliminating 4 stack stores and 4 stack loads.

<details>
<summary>Assembly diff (before → after)</summary>

```diff
--- before
+++ after
@@ -19,51 +19,43 @@
 	.cfi_offset r13, -40
 	.cfi_offset r14, -32
 	.cfi_offset r15, -24
-	mov rdx, qword ptr [rsi + 16]
-	mov r11, qword ptr [rdi]
-	mov rbx, qword ptr [rdi + 8]
+	mov rcx, qword ptr [rdi]
+	mov r9, qword ptr [rdi + 8]
+	mov rdx, qword ptr [rsi]
+	mov r11, qword ptr [rdi + 24]
+	mov r10, qword ptr [rdi + 16]
 	mov rax, qword ptr [rsi + 8]
-	mov rcx, qword ptr [rsi]
-	mov rsi, qword ptr [rsi + 24]
-	mov r12, qword ptr [rdi + 24]
-	mov r13, qword ptr [rdi + 16]
-	mov r10, rdx
-	mulx r9, rdx, r11
-	imul rsi, r11
-	imul r10, rbx
-	imul r12, rcx
-	mov qword ptr [rbp - 64], rdx
-	mov rdx, rax
-	mulx r15, rdx, rbx
-	mov qword ptr [rbp - 56], rdx
-	mov rdx, rax
-	mulx r8, rdx, r11
+	imul r11, rdx
+	mulx r14, rbx, r10
+	mulx r12, r15, r9
+	mulx r13, rdx, rcx
 	mov qword ptr [rbp - 48], rdx
-	mov rdx, rcx
-	mulx rbx, r14, rbx
-	mulx r11, rdx, r11
-	mov qword ptr [rbp - 72], rdx
-	mov rdx, rcx
-	mulx rdx, rcx, r13
-	add r11, r14
-	adc rcx, rbx
-	adc rdx, r12
-	add r11, qword ptr [rbp - 48]
-	adc r8, qword ptr [rbp - 56]
+	mov rdx, rax
+	add r13, r15
+	mulx r15, r8, r9
+	adc r12, rbx
+	adc r14, r11
+	mulx rbx, r11, rcx
+	mov rdx, qword ptr [rsi + 16]
+	add r11, r13
+	adc rbx, r8
 	adc r15, 0
-	imul rax, r13
-	add r8, rcx
-	mov rcx, qword ptr [rbp - 72]
-	adc rax, r15
-	add r8, qword ptr [rbp - 64]
-	mov qword ptr [rdi], rcx
+	add rbx, r12
+	adc r15, r14
+	imul rax, r10
+	mulx r14, r8, rcx
+	add rax, r15
+	add r8, rbx
+	adc r14, rax
+	imul rcx, qword ptr [rsi + 24]
+	imul rdx, r9
+	mov rax, qword ptr [rbp - 48]
+	mov qword ptr [rdi], rax
 	mov qword ptr [rdi + 8], r11
-	adc r9, r10
-	add rax, rdx
-	add rax, r9
 	mov qword ptr [rdi + 16], r8
-	add rax, rsi
-	mov qword ptr [rdi + 24], rax
+	add rcx, rdx
+	add rcx, r14
+	mov qword ptr [rdi + 24], rcx
 	pop rbx
 	pop r12
 	pop r13
```

</details>