### PR TITLE
docs: link to ruint-uniffi for FFI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ RUSTDOCFLAGS="-Z unstable-options --show-coverage"  cargo doc --workspace --all-
 * Compatible with std `u64`, etc types. See Rust's [integer methods](https://doc.rust-lang.org/stable/std/primitive.u64.html).
 * Adhere to [Rust API Guidelines](https://rust-lang.github.io/api-guidelines)
 * Montgomery REDC and other algo's for implementing prime fields.
+* **Community maintained**. Support for use in foreign bindings for Swift and Kotlin though [ruint-uniffi](https://github.com/paolodamico/ruint-uniffi) crate.
 
 ## To do
 


### PR DESCRIPTION
## Motivation

We've been using this new small library https://github.com/paolodamico/ruint-uniffi to support ruint's `Uint` in foreign code (Swift and Kotlin) with their own respective native types (Swift through a third-party library as there's no built-in). This has proven quite useful and thought others may benefit.

## Solution

The `ruint-uniffi` crate facilitates `Uint` aliases for use in foreign code.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog
