### PR TITLE
perf: nudge LLVM codegen good to_bytes_be

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optimize `from_str_radix` ([#557])
 - Specialize `Ord::cmp`, `const_eq`, `const_is_zero` for small sizes ([#561])
 - Use bit shifts for power-of-two formatting (binary, octal, hex) instead of division ([#565])
+- Optimize `to_be_bytes` for full-limb sizes via per-limb `swap_bytes`
 
 [#557]: https://github.com/recmo/uint/pull/557
 [#561]: https://github.com/recmo/uint/pull/561

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -148,6 +148,22 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     #[must_use]
     #[inline]
     pub const fn to_be_bytes<const BYTES: usize>(&self) -> [u8; BYTES] {
+        const { Self::assert_bytes(BYTES) }
+
+        // Optimized implementation for full-limb types: one `bswap` per limb.
+        // The byte-by-byte reverse in the generic fallback is not recognized
+        // by LLVM and degrades to 32 individual byte loads/stores for U256.
+        if BYTES == LIMBS * 8 {
+            let mut limbs_be = [0u64; LIMBS];
+            let mut i = 0;
+            while i < LIMBS {
+                limbs_be[i] = self.limbs[LIMBS - 1 - i].swap_bytes();
+                i += 1;
+            }
+            // SAFETY: BYTES == size_of::<[u64; LIMBS]>().
+            return unsafe { *limbs_be.as_ptr().cast() };
+        }
+
         let mut bytes = self.to_le_bytes::<BYTES>();
 
         // bytes.reverse()


### PR DESCRIPTION
Special case the BYTES = LIMBS * 8 so to compel LLVM generate the proper machine code.

In the wild, it was observed that LLVM[^1] generated very silly code on x86-64,

<details>

<summary>Disassembly on x86-64</summary>

```
;; ── limb3 (rdx) — written BYTE BY BYTE ──
mov    %rdx,%rax                ;  copy limb3
shr    $0x38,%rax               ;  extract byte 0 (bits 63..56)
mov    %al, (%rcx,%rbx)         ;  store byte 0
mov    %rdx,%rax
shr    $0x30,%rax               ;  extract byte 1 (bits 55..48)
mov    %al, 0x1(%rcx,%rbx)      ;  store byte 1
mov    %rdx,%rax
shr    $0x28,%rax               ;  extract byte 2 (bits 47..40)
mov    %al, 0x2(%rcx,%rbx)      ;  store byte 2
mov    %rdx,%rax
shr    $0x20,%rax               ;  extract byte 3 (bits 39..32)
mov    %al, 0x3(%rcx,%rbx)      ;  store byte 3
mov    %edx,%eax
shr    $0x18,%eax               ;  extract byte 4 (bits 31..24)
mov    %al, 0x4(%rcx,%rbx)      ;  store byte 4
mov    %edx,%eax
shr    $0x10,%eax               ;  extract byte 5 (bits 23..16)
mov    %al, 0x5(%rcx,%rbx)      ;  store byte 5
mov    %dh, 0x6(%rcx,%rbx)      ;  store byte 6 (bits 15..8)
mov    %dl, 0x7(%rcx,%rbx)      ;  store byte 7 (bits 7..0)

;; ── limbs 2,1 — bswap+qword ──
bswap  %r15                     ;  byte-swap limb2
mov    %r15, 0x8(%rcx,%rbx)     ;  store 8 bytes at once
bswap  %r14                     ;  byte-swap limb1
mov    %r14, 0x10(%rcx,%rbx)    ;  store 8 bytes at once

;; ── limb0 (r13) — BYTE BY BYTE again ──
mov    %r13,%rax
shr    $0x38,%rax               ;  extract byte 24
mov    %al, 0x18(%rcx,%rbx)     ;  store
mov    %r13,%rax
shr    $0x30,%rax               ;  extract byte 25
mov    %al, 0x19(%rcx,%rbx)     ;  store
mov    %r13,%rax
shr    $0x28,%rax               ;  extract byte 26
mov    %al, 0x1a(%rcx,%rbx)     ;  store
mov    %r13,%rax
shr    $0x20,%rax               ;  extract byte 27
mov    %al, 0x1b(%rcx,%rbx)     ;  store
mov    %eax,%edx
shr    $0x18,%edx               ;  extract byte 28
mov    %dl, 0x1c(%rcx,%rbx)     ;  store
mov    %eax,%edx
shr    $0x10,%edx               ;  extract byte 29
mov    %dl, 0x1d(%rcx,%rbx)     ;  store
mov    %ah, 0x1e(%rcx,%rbx)     ;  store byte 30
mov    %al, 0x1f(%rcx,%rbx)     ;  store byte 31
```

</details>

On M1 every limb was generated byte-by-byte.

This changeset is verified to generate moves + bswap.

[^1]: rustc 1.94.0-nightly (2026-01-12) with LLVM 21.1.8.

