### PR TITLE
chore: bump MSRV to 1.90

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ["stable", "beta", "nightly", "1.85"] # MSRV
+        rust: ["stable", "beta", "nightly", "1.90"] # MSRV
         flags: ["--no-default-features", "", "--all-features"]
         exclude:
           # Skip because some features have higher MSRV.
-          - rust: "1.85" # MSRV
+          - rust: "1.90" # MSRV
             flags: "--all-features"
     steps:
       - uses: actions/checkout@v5
@@ -44,7 +44,7 @@ jobs:
           cache-on-failure: true
       # Only run tests on latest stable and above
       - name: Check
-        if: ${{ matrix.rust == '1.85' }} # MSRV
+        if: ${{ matrix.rust == '1.90' }} # MSRV
         run: cargo check ${{ matrix.flags }}
 
       # Cargo doc test is not included in `--all-targets` so we call it separately.
@@ -52,12 +52,12 @@ jobs:
       # Cargo doc test also doesn't support `--no-run`, so we run it but
       # have it just print `--help`.
       - name: Build tests
-        if: ${{ matrix.rust != '1.85' }} # MSRV
+        if: ${{ matrix.rust != '1.90' }} # MSRV
         run: |
           cargo test --workspace ${{ matrix.flags }} --all-targets --no-run
           cargo test --workspace ${{ matrix.flags }} --doc -- --help
       - name: Run tests
-        if: ${{ matrix.rust != '1.85' }} # MSRV
+        if: ${{ matrix.rust != '1.90' }} # MSRV
         run: |
           cargo test --workspace ${{ matrix.flags }} --all-targets -- --nocapture
           cargo test --workspace ${{ matrix.flags }} --doc -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.90"
 authors = ["Remco Bloemen <remco@wicked.ventures>"]
 license = "MIT"
 homepage = "https://github.com/recmo/uint"

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ When updating this, also update:
 
 Uint will keep a rolling MSRV (minimum supported rust version) policy of **at
 least** 6 months. When increasing the MSRV, the new Rust version must have been
-released at least six months ago. The current MSRV is 1.85.0.
+released at least six months ago. The current MSRV is 1.90.0.
 
 Note that the MSRV is not increased automatically, and only as part of a minor
 release.

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -149,18 +149,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     #[inline]
     pub const fn to_be_bytes<const BYTES: usize>(&self) -> [u8; BYTES] {
         let mut bytes = self.to_le_bytes::<BYTES>();
-
-        // bytes.reverse()
-        let len = bytes.len();
-        let half_len = len / 2;
-        let mut i = 0;
-        while i < half_len {
-            let tmp = bytes[i];
-            bytes[i] = bytes[len - 1 - i];
-            bytes[len - 1 - i] = tmp;
-            i += 1;
-        }
-
+        bytes.reverse();
         bytes
     }
 


### PR DESCRIPTION
Replace the manual const reverse loop in `to_be_bytes` with `bytes.reverse()`, which is const-stable as of Rust 1.90.