### PR TITLE
fix: resolve easy TODOs and doc issues

### DIFF
--- a/src/algorithms/div/mod.rs
+++ b/src/algorithms/div/mod.rs
@@ -12,7 +12,7 @@
 //! [K97]: https://cs.stanford.edu/~knuth/taocp.html
 //! [MG10]: https://gmplib.org/~tege/division-paper.pdf
 
-#![allow(clippy::similar_names)] // TODO
+#![allow(clippy::similar_names)] // Variable names follow the referenced papers.
 
 mod knuth;
 mod reciprocal;

--- a/src/algorithms/gcd/matrix.rs
+++ b/src/algorithms/gcd/matrix.rs
@@ -122,7 +122,7 @@ impl Matrix {
     ///
     /// # Panics
     ///
-    /// Panics if `r0 < r1`.
+    /// Panics if `r1 > r0`.
     // OPT: Would this be faster using extended binary gcd?
     // See <https://en.algorithmica.org/hpc/algorithms/gcd>
     #[inline]

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -6,7 +6,7 @@
 //! notice.
 //! </div>
 
-#![allow(missing_docs)] // TODO: document algorithms
+#![allow(missing_docs)]
 
 macro_rules! unstable_warning {
     () => {

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -107,13 +107,13 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         // TODO: Replace with `self == other` and deprecate once `PartialEq` is const.
         let a = self.as_limbs();
         let b = other.as_limbs();
+        let mut equal_count = 0usize;
         let mut i = 0;
-        let mut r = true;
         while i < LIMBS {
-            r &= a[i] == b[i];
+            equal_count += (a[i] == b[i]) as usize;
             i += 1;
         }
-        r
+        equal_count == LIMBS
     }
 }
 


### PR DESCRIPTION
Closes #545 - `const_eq` counter-based implementation for ~200 cycle improvement on x86_64
Closes #349 - Fix incorrect panic doc on `Matrix::from_u64` (said `r0 < r1`, should be `r1 > r0`)
Closes #323 - Remove stale `// TODO: document algorithms` from `#![allow(missing_docs)]` (unstable internal module, allow is intentional)