### PR TITLE
chore: remove clippy msrv

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,0 @@
-msrv = "1.85"
-doc-valid-idents = ["CPython", "PyPy", ".."]

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -114,7 +114,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         for limb in &mut self.limbs {
             *limb = limb.reverse_bits();
         }
-        if BITS % 64 != 0 {
+        if !BITS.is_multiple_of(64) {
             self >>= 64 - BITS % 64;
         }
         self

--- a/src/log.rs
+++ b/src/log.rs
@@ -75,11 +75,11 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
             break;
         }
         while let Some(trial) = result.checked_add(Self::ONE) {
-            if let Some(value) = base.checked_pow(trial) {
-                if value <= self {
-                    result = trial;
-                    continue;
-                }
+            if let Some(value) = base.checked_pow(trial)
+                && value <= self
+            {
+                result = trial;
+                continue;
             }
             break;
         }

--- a/src/support/pyo3.rs
+++ b/src/support/pyo3.rs
@@ -115,13 +115,13 @@ impl<'a, const BITS: usize, const LIMBS: usize> FromPyObject<'a> for Uint<BITS, 
 
         // Check mask since we wrote raw.
         #[cfg(target_endian = "little")]
-        if let Some(last) = result.as_limbs().last() {
-            if *last > Self::MASK {
-                return Err(PyOverflowError::new_err(format!(
-                    "Number to large to fit Uint<{}>",
-                    Self::BITS
-                )));
-            }
+        if let Some(last) = result.as_limbs().last()
+            && *last > Self::MASK
+        {
+            return Err(PyOverflowError::new_err(format!(
+                "Number to large to fit Uint<{}>",
+                Self::BITS
+            )));
         }
 
         Ok(result)

--- a/src/support/scale.rs
+++ b/src/support/scale.rs
@@ -240,7 +240,7 @@ impl<const BITS: usize, const LIMBS: usize> Decode for CompactUint<BITS, LIMBS> 
 
                     let mut new_limbs = vec![u64::MAX; limbs];
                     if bits > 0 {
-                        new_limbs[limbs - 1] &= if bits % 64 == 0 {
+                        new_limbs[limbs - 1] &= if bits.is_multiple_of(64) {
                             u64::MAX
                         } else {
                             (1 << (bits % 64)) - 1


### PR DESCRIPTION
Clippy MSRV is out of sync. It defaults to project Rust version so we can just remove the file.