### PR TITLE
Fix `to_be_bytes` on big-endian platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix `to_be_bytes` on big-endian platforms ([#576])
+
 ## [1.18.0] - 2026-04-22
 
 ### Changed

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -157,8 +157,24 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
             let mut limbs_be = [0u64; LIMBS];
             let mut i = 0;
             while i < LIMBS {
-                limbs_be[i] = self.limbs[LIMBS - 1 - i].swap_bytes();
+                #[cfg(target_endian = "big")]
+                {
+                    limbs_be[i] = self.limbs[LIMBS - 1 - i];
+                }
+                #[cfg(target_endian = "little")]
+                {
+                    limbs_be[i] = self.limbs[LIMBS - 1 - i].swap_bytes();
+                }
                 i += 1;
+            }
+            const {
+                assert!(
+                    core::mem::size_of::<[u64; LIMBS]>() == core::mem::size_of::<[u8; BYTES]>()
+                );
+                assert!(
+                    core::mem::align_of::<[u64; LIMBS]>()
+                        .is_multiple_of(core::mem::align_of::<[u8; BYTES]>())
+                );
             }
             // SAFETY: BYTES == size_of::<[u64; LIMBS]>().
             return unsafe { *limbs_be.as_ptr().cast() };


### PR DESCRIPTION
This assumed `u64` would have a little-endian representation and unconditionally call `swap_bytes`.