### PR TITLE
perf: compare using subtraction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.91"
+rust-version = "1.90"
 authors = ["Remco Bloemen <remco@wicked.ventures>"]
 license = "MIT"
 homepage = "https://github.com/recmo/uint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.90"
+rust-version = "1.91"
 authors = ["Remco Bloemen <remco@wicked.ventures>"]
 license = "MIT"
 homepage = "https://github.com/recmo/uint"

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -17,6 +17,9 @@ pub(crate) use unstable_warning;
 
 use core::cmp::Ordering;
 
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::_subborrow_u64;
+
 mod add;
 pub mod div;
 mod gcd;
@@ -144,6 +147,33 @@ cmp_fns! {
 #[inline]
 fn sub(a: &[u64], b: &[u64]) -> (u64, bool) {
     assume!(a.len() == b.len());
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        sub_x86_64(a, b)
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        sub_fallback(a, b)
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn sub_x86_64(a: &[u64], b: &[u64]) -> (u64, bool) {
+    let mut borrow = 0;
+    let mut acc = 0;
+    for i in 0..a.len() {
+        let mut x = 0;
+        borrow = _subborrow_u64(borrow, a[i], b[i], &mut x);
+        acc |= x;
+    }
+    (acc, borrow != 0)
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+#[inline]
+fn sub_fallback(a: &[u64], b: &[u64]) -> (u64, bool) {
     let mut borrow = false;
     let mut acc = 0;
     for i in 0..a.len() {

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -165,7 +165,11 @@ fn sub_x86_64(a: &[u64], b: &[u64]) -> (u64, bool) {
     let mut acc = 0;
     for i in 0..a.len() {
         let mut x = 0;
-        borrow = _subborrow_u64(borrow, a[i], b[i], &mut x);
+        // SAFETY: `_subborrow_u64` has no target features beyond x86-64.
+        #[allow(unused_unsafe)]
+        unsafe {
+            borrow = _subborrow_u64(borrow, a[i], b[i], &mut x);
+        }
         acc |= x;
     }
     (acc, borrow != 0)

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -148,9 +148,13 @@ fn sub(a: &[u64], b: &[u64]) -> (u64, bool) {
     let mut acc = 0;
     for i in 0..a.len() {
         let x;
-        (x, borrow) = a[i].borrowing_sub(b[i], borrow);
+        (x, borrow) = borrowing_sub(a[i], b[i], borrow);
         acc |= x;
     }
+    // HACK: This is a hack to avoid the compiler optimizing too much that the
+    // backend doesn't recognize the `borrowing_sub` chain: https://github.com/rust-lang/rust/issues/143517
+    // SAFETY: Writing to a local variable through a reference is safe.
+    unsafe { core::ptr::write_volatile(&mut acc, acc) };
     (acc, borrow)
 }
 

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -148,13 +148,9 @@ fn sub(a: &[u64], b: &[u64]) -> (u64, bool) {
     let mut acc = 0;
     for i in 0..a.len() {
         let x;
-        (x, borrow) = borrowing_sub(a[i], b[i], borrow);
+        (x, borrow) = a[i].borrowing_sub(b[i], borrow);
         acc |= x;
     }
-    // HACK: This is a hack to avoid the compiler optimizing too much that the
-    // backend doesn't recognize the `borrowing_sub` chain: https://github.com/rust-lang/rust/issues/143517
-    // SAFETY: Writing to a local variable through a reference is safe.
-    unsafe { core::ptr::write_volatile(&mut acc, acc) };
     (acc, borrow)
 }
 

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -103,22 +103,59 @@ pub fn cmp(a: &[u64], b: &[u64]) -> Ordering {
         Ordering::Equal => {}
         non_eq => return non_eq,
     }
-    for i in (0..a.len()).rev() {
-        match i8::from(a[i] > b[i]) - i8::from(a[i] < b[i]) {
-            -1 => return Ordering::Less,
-            0 => {}
-            1 => return Ordering::Greater,
-            _ => unsafe { core::hint::unreachable_unchecked() },
-        }
-
-        // Equivalent to the following code, but on older rustc versions
-        // performs better:
-        // match a[i].cmp(&b[i]) {
-        //     Ordering::Equal => {}
-        //     non_eq => return non_eq,
-        // }
+    let (r, o) = sub(a, b);
+    if r == 0 {
+        Ordering::Equal
+    } else if o {
+        Ordering::Less
+    } else {
+        Ordering::Greater
     }
-    Ordering::Equal
+}
+
+macro_rules! cmp_fns {
+    ($($name:ident, $op:literal => |$a:ident, $b:ident| $impl:expr),* $(,)?) => {
+        $(
+            /// Compare two limb slices in reverse order, returns `true` if
+            #[doc = concat!("`a ", $op, " b`.")]
+            ///
+            /// Assumes that if the slices are of different length, the longer slice is
+            /// always greater than the shorter slice.
+            #[inline(always)]
+            #[must_use]
+            pub fn $name($a: &[u64], $b: &[u64]) -> bool {
+                $impl
+            }
+        )*
+    };
+}
+
+cmp_fns! {
+    lt, "<"  => |a, b| match a.len().cmp(&b.len()) {
+        Ordering::Equal => sub(a, b).1,
+        non_eq => non_eq.is_lt(),
+    },
+    gt, ">"  => |a, b| lt(b, a),
+    ge, ">=" => |a, b| !lt(a, b),
+    le, "<=" => |a, b| !lt(b, a),
+}
+
+/// `a - b`, returns `((a - b).fold(0, bit_or), overflow)`.
+#[inline]
+fn sub(a: &[u64], b: &[u64]) -> (u64, bool) {
+    assume!(a.len() == b.len());
+    let mut borrow = false;
+    let mut acc = 0;
+    for i in 0..a.len() {
+        let x;
+        (x, borrow) = borrowing_sub(a[i], b[i], borrow);
+        acc |= x;
+    }
+    // HACK: This is a hack to avoid the compiler optimizing too much that the
+    // backend doesn't recognize the `borrowing_sub` chain: https://github.com/rust-lang/rust/issues/143517
+    // SAFETY: Writing to a local variable through a reference is safe.
+    unsafe { core::ptr::write_volatile(&mut acc, acc) };
+    (acc, borrow)
 }
 
 #[inline]

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -185,8 +185,9 @@ fn sub_fallback(a: &[u64], b: &[u64]) -> (u64, bool) {
         (x, borrow) = borrowing_sub(a[i], b[i], borrow);
         acc |= x;
     }
-    // HACK: This is a hack to avoid the compiler optimizing too much that the
-    // backend doesn't recognize the `borrowing_sub` chain: https://github.com/rust-lang/rust/issues/143517
+    // HACK: This only black-boxes `acc` so LLVM keeps the subtraction results
+    // alive long enough for the backend to recognize the `borrowing_sub` chain
+    // and generate better code: https://github.com/rust-lang/rust/issues/143517
     // SAFETY: Writing to a local variable through a reference is safe.
     unsafe { core::ptr::write_volatile(&mut acc, acc) };
     (acc, borrow)

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -39,14 +39,7 @@ impl<const BITS: usize, const LIMBS: usize> Ord for Uint<BITS, LIMBS> {
             u64(x, y) => return x.cmp(&y),
             u128(x, y) => return x.cmp(&y),
         });
-        let (r, o) = self.overflowing_sub(*rhs);
-        if r.is_zero() {
-            Ordering::Equal
-        } else if o {
-            Ordering::Less
-        } else {
-            Ordering::Greater
-        }
+        algorithms::cmp(self.as_limbs(), rhs.as_limbs())
     }
 }
 

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -1,10 +1,34 @@
-use crate::Uint;
+use crate::{Uint, algorithms};
 use core::cmp::Ordering;
+
+macro_rules! cmp_fns {
+    ($($name:ident, $op:tt => |$a:ident, $b:ident| $impl:expr),* $(,)?) => {
+        $(
+            #[inline]
+            fn $name(&self, $b: &Self) -> bool {
+                let $a = self;
+                as_primitives!($a, $b; {
+                    u64(x, y) => return x $op y,
+                    u128(x, y) => return x $op y,
+                });
+
+                $impl
+            }
+        )*
+    };
+}
 
 impl<const BITS: usize, const LIMBS: usize> PartialOrd for Uint<BITS, LIMBS> {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+
+    cmp_fns! {
+        lt, <  => |a, b| algorithms::lt(a.as_limbs(), b.as_limbs()),
+        gt, >  => |a, b| Self::lt(b, a),
+        ge, >= => |a, b| !Self::lt(a, b),
+        le, <= => |a, b| !Self::lt(b, a),
     }
 }
 
@@ -15,7 +39,14 @@ impl<const BITS: usize, const LIMBS: usize> Ord for Uint<BITS, LIMBS> {
             u64(x, y) => return x.cmp(&y),
             u128(x, y) => return x.cmp(&y),
         });
-        crate::algorithms::cmp(self.as_limbs(), rhs.as_limbs())
+        let (r, o) = self.overflowing_sub(*rhs);
+        if r.is_zero() {
+            Ordering::Equal
+        } else if o {
+            Ordering::Less
+        } else {
+            Ordering::Greater
+        }
     }
 }
 
@@ -119,7 +150,37 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
 
 #[cfg(test)]
 mod tests {
-    use crate::Uint;
+    use crate::{Uint, const_for, nlimbs};
+    use core::cmp::Ordering;
+    use proptest::{prop_assert_eq, proptest};
+
+    fn reference_cmp<const BITS: usize, const LIMBS: usize>(
+        a: &Uint<BITS, LIMBS>,
+        b: &Uint<BITS, LIMBS>,
+    ) -> Ordering {
+        let mut i = LIMBS;
+        while i > 0 {
+            i -= 1;
+            match a.as_limbs()[i].cmp(&b.as_limbs()[i]) {
+                Ordering::Equal => {}
+                non_eq => return non_eq,
+            }
+        }
+        Ordering::Equal
+    }
+
+    fn check_cmp<const BITS: usize, const LIMBS: usize>(
+        a: Uint<BITS, LIMBS>,
+        b: Uint<BITS, LIMBS>,
+    ) -> Result<(), proptest::prelude::TestCaseError> {
+        let cmp = reference_cmp(&a, &b);
+        prop_assert_eq!(a.cmp(&b), cmp);
+        prop_assert_eq!(a < b, cmp.is_lt());
+        prop_assert_eq!(a > b, cmp.is_gt());
+        prop_assert_eq!(a <= b, !cmp.is_gt());
+        prop_assert_eq!(a >= b, !cmp.is_lt());
+        Ok(())
+    }
 
     #[test]
     fn test_is_zero() {
@@ -131,5 +192,16 @@ mod tests {
         assert!(!Uint::<1, 1>::from_limbs([1]).is_zero());
         assert!(!Uint::<7, 1>::from_limbs([1]).is_zero());
         assert!(!Uint::<64, 1>::from_limbs([1]).is_zero());
+    }
+
+    #[test]
+    fn test_cmp() {
+        const_for!(BITS in SIZES {
+            const LIMBS: usize = nlimbs(BITS);
+            type U = Uint<BITS, LIMBS>;
+            proptest!(|(a: U, b: U)| {
+                check_cmp(a, b)?;
+            });
+        });
     }
 }


### PR DESCRIPTION
This resurrects the comparison approach from #489 on top of current main.

It implements limb-slice comparison through a borrow chain over `a - b`, using the accumulated difference to detect equality and the final borrow to detect ordering. `Ord::cmp` and the `PartialOrd` relational operators use the algorithms module directly.

On x86-64, the implementation uses the stable `_subborrow_u64` intrinsic, which lowers to `llvm.x86.subborrow.64` and lets LLVM select the `sub/sbb` chain without the volatile codegen hack. Other targets keep the existing `borrowing_sub` helper and volatile fallback to preserve the borrow-chain shape there.

For U256, the relational operators lower to the same core `cmp/sbb/sbb/sbb/setcc` shape as LLVM `i256 icmp`. LLVM's `llvm.ucmp.i32.i256` / C++ `<=>` lowering for `cmp` uses two borrow chains, while this implementation uses one borrow chain plus an OR-reduction of the subtraction result to detect equality.

The existing primitive specializations for u64 and u128 remain in place. Tests compare `cmp`, `<`, `>`, `<=`, and `>=` against an independent high-to-low limb reference across the existing SIZES set.
