### PR TITLE
ci: make Accept gate fail when any required job fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,10 @@ jobs:
     if: always()
     needs: [test, feature-checks, clippy, docs, fmt]
     steps:
-      - name: Check all needs succeeded
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
-        run: exit 1
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,12 @@ jobs:
   accept:
     name: Accept
     runs-on: ubuntu-latest
+    if: always()
     needs: [test, feature-checks, clippy, docs, fmt]
     steps:
-      - name: Accept
-        run: "true"
+      - name: Check all needs succeeded
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: exit 1
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The `Accept` job in `ci.yml` was a single-step `run: "true"` that depended on all the real CI jobs. With default GitHub Actions semantics, when any job in `needs:` fails, dependent jobs are **skipped**, not failed.

GitHub branch protection treats a `skipped` required status check as non-blocking, so the required `Accept` check never reported `failure` even when `test`/`clippy` failed. PR #576 hit exactly this — automerge fired with failing CI because `Accept` was reported as `skipped` rather than `failure`.

This PR runs `Accept` unconditionally (`if: always()`) and explicitly fails when any dep is not `success`, turning it into a real failing required check that branch protection blocks on.

## Test plan

- [ ] Open this PR; confirm `Accept` runs and reports `success` when all jobs pass.
- [ ] Push a commit that breaks a test on a draft PR; confirm `Accept` reports `failure` (not `skipped`) and that branch protection blocks merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)