### PR TITLE
refactor: replace double word trait

### DIFF
--- a/src/algorithms/div/knuth.rs
+++ b/src/algorithms/div/knuth.rs
@@ -1,6 +1,6 @@
 //! Knuth division
 
-use super::{DoubleWord, reciprocal::reciprocal_2, small::div_3x2};
+use super::{DW, reciprocal::reciprocal_2, small::div_3x2};
 use crate::{
     algorithms::{add::carrying_add_n, mul::submul_nx1},
     utils::{UncheckedSlice, likely, unlikely},
@@ -32,14 +32,14 @@ pub unsafe fn div_nxm_normalized(numerator: &mut [u64], divisor: &[u64]) {
     let m = numerator.len() - n - 1;
 
     // Compute the divisor double limb and reciprocal
-    let d = u128::join(divisor[n - 1], divisor[n - 2]);
+    let d = DW::join(divisor[n - 1], divisor[n - 2]);
 
     let v = unsafe { reciprocal_2(d) };
 
     // Compute the quotient one limb at a time.
     for j in (0..=m).rev() {
         // Fetch the first three limbs of the numerator.
-        let n21 = u128::join(numerator[j + n], numerator[j + n - 1]);
+        let n21 = DW::join(numerator[j + n], numerator[j + n - 1]);
         let n0 = numerator[j + n - 2];
         debug_assert!(n21 <= d);
 
@@ -62,8 +62,8 @@ pub unsafe fn div_nxm_normalized(numerator: &mut [u64], divisor: &[u64]) {
         // computation. We still need to carry propagate into these limbs.
         let borrow = submul_nx1(&mut numerator[j..j + n - 2], &divisor[..n - 2], q);
         let (r, borrow) = r.overflowing_sub(u128::from(borrow));
-        numerator[j + n - 2] = r.low();
-        numerator[j + n - 1] = r.high();
+        numerator[j + n - 2] = DW::low(r);
+        numerator[j + n - 1] = DW::high(r);
 
         // If we have a carry then the quotient was one too large.
         // We correct by decrementing the quotient and adding one divisor back.
@@ -109,8 +109,8 @@ pub unsafe fn div_nxm(numerator: &mut [u64], divisor: &mut [u64]) {
     // Compute normalized divisor double-word and reciprocal.
     // TODO: Delegate to div_nxm_normalized if normalized.
     let (d, shift) = {
-        let d = u128::join(divisor[n - 1], divisor[n - 2]);
-        let shift = d.high().leading_zeros();
+        let d = DW::join(divisor[n - 1], divisor[n - 2]);
+        let shift = DW::high(d).leading_zeros();
         (
             if shift == 0 {
                 d
@@ -132,7 +132,7 @@ pub unsafe fn div_nxm(numerator: &mut [u64], divisor: &mut [u64]) {
         // Fetch the first three limbs of the shifted numerator starting at `j + n`.
         let (n21, n0) = {
             let n2 = numerator.get(j + n).copied().unwrap_or_default();
-            let n21 = u128::join(n2, numerator[j + n - 1]);
+            let n21 = DW::join(n2, numerator[j + n - 1]);
             let n0 = numerator[j + n - 2];
             if shift == 0 {
                 (n21, n0)
@@ -160,8 +160,8 @@ pub unsafe fn div_nxm(numerator: &mut [u64], divisor: &mut [u64]) {
                 let borrow = if shift == 0 {
                     let borrow = submul_nx1(&mut numerator[j..j + n - 2], &divisor[..n - 2], q);
                     let (r, borrow) = r.overflowing_sub(u128::from(borrow));
-                    numerator[j + n - 2] = r.low();
-                    numerator[j + n - 1] = r.high();
+                    numerator[j + n - 2] = DW::low(r);
+                    numerator[j + n - 1] = DW::high(r);
                     borrow
                 } else {
                     // OPT: Can we re-use `r` here somehow? The problem is we can not just

--- a/src/algorithms/div/mod.rs
+++ b/src/algorithms/div/mod.rs
@@ -29,7 +29,7 @@ pub use self::{
         div_nx1_normalized, div_nx2, div_nx2_normalized,
     },
 };
-use crate::{algorithms::DoubleWord, utils::cold_path};
+use crate::{algorithms::DW, utils::cold_path};
 
 /// ⚠️ Division with remainder.
 #[doc = crate::algorithms::unstable_warning!()]
@@ -77,7 +77,7 @@ pub(crate) fn div_inlined(numerator: &mut [u64], divisor: &mut [u64]) {
     }
     debug_assert_ne!(*numerator.last().unwrap(), 0);
 
-    if super::cmp(numerator, divisor).is_lt() {
+    if super::lt(numerator, divisor) {
         // Numerator is smaller than the divisor: (q, r) = (0, numerator)
         cold_path();
         // `a < b` implies `a.len() <= b.len()`,
@@ -127,8 +127,8 @@ pub(crate) fn div_inlined(numerator: &mut [u64], divisor: &mut [u64]) {
             }
         }
         [d0, d1] => {
-            let d = u128::join(*d1, *d0);
-            (*d0, *d1) = unsafe { div_nx2(numerator, d) }.split();
+            let d = DW::join(*d1, *d0);
+            (*d0, *d1) = DW::split(unsafe { div_nx2(numerator, d) });
         }
         _ => unsafe { div_nxm(numerator, divisor) },
     }

--- a/src/algorithms/div/reciprocal.rs
+++ b/src/algorithms/div/reciprocal.rs
@@ -6,7 +6,7 @@
 //! [new]: https://gmplib.org/list-archives/gmp-devel/2019-October/005590.html
 #![allow(dead_code, clippy::cast_possible_truncation, clippy::cast_lossless)]
 
-use crate::algorithms::DoubleWord;
+use crate::algorithms::DW;
 use core::num::Wrapping;
 
 pub use self::{
@@ -134,7 +134,7 @@ pub fn checked_reciprocal_mg10(d: u64) -> Option<u64> {
 #[must_use]
 pub unsafe fn reciprocal_2_mg10(d: u128) -> u64 {
     debug_assert!(d >= (1 << 127));
-    let (d_low, d_high) = d.split();
+    let (d_low, d_high) = DW::split(d);
 
     // SAFETY: High bit is set in d, so high bit will be set in d_high.
     let mut v = unsafe { reciprocal(d_high) };
@@ -147,12 +147,12 @@ pub unsafe fn reciprocal_2_mg10(d: u128) -> u64 {
         }
         p = p.wrapping_sub(d_high);
     }
-    let (t0, t1) = u128::mul(v, d_low).split();
+    let (t0, t1) = DW::split(DW::mul(v, d_low));
 
     let (p, overflow) = p.overflowing_add(t1);
     if overflow {
         v = v.wrapping_sub(1);
-        if u128::join(p, t0) >= d {
+        if DW::join(p, t0) >= d {
             v = v.wrapping_sub(1);
         }
     }
@@ -178,13 +178,13 @@ pub fn checked_reciprocal_2_mg10(d: u128) -> Option<u64> {
 #[inline(always)]
 #[must_use]
 fn mul_hi(a: Wrapping<u64>, b: Wrapping<u64>) -> Wrapping<u64> {
-    Wrapping(u128::mul(a.0, b.0).high())
+    Wrapping(DW::high(DW::mul(a.0, b.0)))
 }
 
 #[inline(always)]
 #[must_use]
 fn muladd_hi(a: Wrapping<u64>, b: Wrapping<u64>, c: Wrapping<u64>) -> Wrapping<u64> {
-    Wrapping(u128::muladd(a.0, b.0, c.0).high())
+    Wrapping(DW::high(DW::muladd(a.0, b.0, c.0)))
 }
 
 #[cfg(test)]

--- a/src/algorithms/div/small.rs
+++ b/src/algorithms/div/small.rs
@@ -9,7 +9,7 @@
 
 use super::reciprocal::{reciprocal, reciprocal_2};
 use crate::{
-    algorithms::DoubleWord,
+    algorithms::DW,
     utils::{UncheckedSlice, unlikely},
 };
 
@@ -44,7 +44,7 @@ pub unsafe fn div_nx1_normalized(u: &mut [u64], d: u64) -> u64 {
     let v = unsafe { reciprocal(d) };
     let mut r: u64 = 0;
     for u in u.iter_mut().rev() {
-        let n = u128::join(r, *u);
+        let n = DW::join(r, *u);
         let (q, r0) = div_2x1(n, d, v);
         *u = q;
         r = r0;
@@ -92,7 +92,7 @@ pub unsafe fn div_nx1(limbs: &mut [u64], divisor: u64) -> u64 {
         let u = (upper << shift) | (lower >> (64 - shift));
 
         // Compute quotient
-        let n = u128::join(remainder, u);
+        let n = DW::join(remainder, u);
         let (q, r) = div_2x1(n, divisor, reciprocal);
 
         // Store quotient
@@ -101,7 +101,7 @@ pub unsafe fn div_nx1(limbs: &mut [u64], divisor: u64) -> u64 {
     }
     // Compute last quotient
     let first = limbs[0];
-    let n = u128::join(remainder, first << shift);
+    let n = DW::join(remainder, first << shift);
     let (q, remainder) = div_2x1(n, divisor, reciprocal);
     limbs[0] = q;
 
@@ -161,7 +161,7 @@ pub unsafe fn div_nx2(limbs: &mut [u64], divisor: u128) -> u128 {
     let limbs = UncheckedSlice::wrap_mut(limbs);
 
     // Normalize and compute reciprocal
-    let shift = divisor.high().leading_zeros();
+    let shift = DW::high(divisor).leading_zeros();
     if shift == 0 {
         return unsafe { div_nx2_normalized(limbs, divisor) };
     }
@@ -315,12 +315,12 @@ pub unsafe fn div_3x2_mg10(u21: u128, u0: u64, d: u128, v: u64) -> (u64, u128) {
     debug_assert!(u21 < d);
     debug_assert_eq!(v, unsafe { reciprocal_2(d) });
 
-    let q = u128::mul(u21.high(), v) + u21;
-    let r1 = u21.low().wrapping_sub(q.high().wrapping_mul(d.high()));
-    let t = u128::mul(d.low(), q.high());
-    let mut r = u128::join(r1, u0).wrapping_sub(t).wrapping_sub(d);
-    let mut q1 = q.high().wrapping_add(1);
-    if r.high() >= q.low() {
+    let q = DW::mul(DW::high(u21), v) + u21;
+    let r1 = DW::low(u21).wrapping_sub(DW::high(q).wrapping_mul(DW::high(d)));
+    let t = DW::mul(DW::low(d), DW::high(q));
+    let mut r = DW::join(r1, u0).wrapping_sub(t).wrapping_sub(d);
+    let mut q1 = DW::high(q).wrapping_add(1);
+    if DW::high(r) >= DW::low(q) {
         q1 = q1.wrapping_sub(1);
         r = r.wrapping_add(d);
     }
@@ -443,9 +443,9 @@ mod tests {
         proptest!(|(quotient in any_vec, (divisor, remainder) in divrem)| {
             // Construct problem
             let mut numerator = vec![0; quotient.len() + 2];
-            numerator[0] = remainder.low();
-            numerator[1] = remainder.high();
-            addmul(&mut numerator, &quotient, &[divisor.low(), divisor.high()]);
+            numerator[0] = DW::low(remainder);
+            numerator[1] = DW::high(remainder);
+            addmul(&mut numerator, &quotient, &[DW::low(divisor), DW::high(divisor)]);
 
             // Test
             let r = unsafe { div_nx2_normalized(&mut numerator, divisor) };
@@ -461,9 +461,9 @@ mod tests {
         proptest!(|(quotient in any_vec,(divisor, remainder) in divrem)| {
             // Construct problem
             let mut numerator = vec![0; quotient.len() + 2];
-            numerator[0] = remainder.low();
-            numerator[1] = remainder.high();
-            addmul(&mut numerator, &quotient, &[divisor.low(), divisor.high()]);
+            numerator[0] = DW::low(remainder);
+            numerator[1] = DW::high(remainder);
+            addmul(&mut numerator, &quotient, &[DW::low(divisor), DW::high(divisor)]);
 
             // Trim numerator
             while numerator.last() == Some(&0) {

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -34,55 +34,25 @@ pub use self::{
     mul_redc::{mul_redc, square_redc},
 };
 
-pub(crate) trait DoubleWord<T: Default>: Sized + Copy {
+pub(crate) struct DW;
+
+#[allow(clippy::cast_lossless, clippy::cast_possible_truncation)]
+impl DW {
     /// `high << 64 | low`
-    fn join(high: T, low: T) -> Self;
+    #[inline(always)]
+    pub(crate) const fn join(high: u64, low: u64) -> u128 {
+        ((high as u128) << 64) | low as u128
+    }
+
     /// `(low, high)`
-    fn split(self) -> (T, T);
+    #[inline(always)]
+    pub(crate) const fn split(double: u128) -> (u64, u64) {
+        (double as u64, (double >> 64) as u64)
+    }
 
     /// `a * b + c + d`
-    fn muladd2(a: T, b: T, c: T, d: T) -> Self;
-
-    /// `a + b`
     #[inline(always)]
-    fn add(a: T, b: T) -> Self {
-        Self::muladd2(T::default(), T::default(), a, b)
-    }
-    /// `a * b`
-    #[inline(always)]
-    fn mul(a: T, b: T) -> Self {
-        Self::muladd2(a, b, T::default(), T::default())
-    }
-    /// `a * b + c`
-    #[inline(always)]
-    fn muladd(a: T, b: T, c: T) -> Self {
-        Self::muladd2(a, b, c, T::default())
-    }
-
-    #[inline(always)]
-    fn high(self) -> T {
-        self.split().1
-    }
-    #[inline(always)]
-    fn low(self) -> T {
-        self.split().0
-    }
-}
-
-#[allow(clippy::cast_possible_truncation)]
-impl DoubleWord<u64> for u128 {
-    #[inline(always)]
-    fn join(high: u64, low: u64) -> Self {
-        (Self::from(high) << 64) | Self::from(low)
-    }
-
-    #[inline(always)]
-    fn split(self) -> (u64, u64) {
-        (self as u64, (self >> 64) as u64)
-    }
-
-    #[inline(always)]
-    fn muladd2(a: u64, b: u64, c: u64, d: u64) -> Self {
+    pub(crate) const fn muladd2(a: u64, b: u64, c: u64, d: u64) -> u128 {
         #[cfg(feature = "nightly")]
         {
             let (low, high) = u64::carrying_mul_add(a, b, c, d);
@@ -90,8 +60,36 @@ impl DoubleWord<u64> for u128 {
         }
         #[cfg(not(feature = "nightly"))]
         {
-            Self::from(a) * Self::from(b) + Self::from(c) + Self::from(d)
+            (a as u128) * (b as u128) + (c as u128) + (d as u128)
         }
+    }
+
+    /// `a + b`
+    #[inline(always)]
+    pub(crate) const fn add(a: u64, b: u64) -> u128 {
+        Self::muladd2(0, 0, a, b)
+    }
+
+    /// `a * b`
+    #[inline(always)]
+    pub(crate) const fn mul(a: u64, b: u64) -> u128 {
+        Self::muladd2(a, b, 0, 0)
+    }
+
+    /// `a * b + c`
+    #[inline(always)]
+    pub(crate) const fn muladd(a: u64, b: u64, c: u64) -> u128 {
+        Self::muladd2(a, b, c, 0)
+    }
+
+    #[inline(always)]
+    pub(crate) const fn high(double: u128) -> u64 {
+        Self::split(double).1
+    }
+
+    #[inline(always)]
+    pub(crate) const fn low(double: u128) -> u64 {
+        Self::split(double).0
     }
 }
 

--- a/src/algorithms/mul.rs
+++ b/src/algorithms/mul.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::module_name_repetitions)]
 
-use crate::algorithms::{DoubleWord, borrowing_sub};
+use crate::algorithms::{DW, borrowing_sub};
 
 /// ⚠️ Computes `result += a * b` and checks for overflow.
 #[doc = crate::algorithms::unstable_warning!()]
@@ -100,7 +100,7 @@ fn addmul_n_small(lhs: &mut [u64], a: &[u64], b: &[u64]) {
         // Widening multiply-accumulate for all but the last position.
         let i = n - j - 1;
         for i in 0..i {
-            (lhs[j + i], carry) = u128::muladd2(a[i], b[j], carry, lhs[j + i]).split();
+            (lhs[j + i], carry) = DW::split(DW::muladd2(a[i], b[j], carry, lhs[j + i]));
         }
         // Last position: the carry out is discarded (it would go beyond n
         // limbs), so use truncated arithmetic to reduce register pressure.
@@ -118,7 +118,7 @@ pub fn add_nx1(lhs: &mut [u64], mut a: u64) -> u64 {
         return 0;
     }
     for lhs in lhs {
-        (*lhs, a) = u128::add(*lhs, a).split();
+        (*lhs, a) = DW::split(DW::add(*lhs, a));
         if a == 0 {
             return 0;
         }
@@ -132,7 +132,7 @@ pub fn add_nx1(lhs: &mut [u64], mut a: u64) -> u64 {
 pub fn mul_nx1(lhs: &mut [u64], a: u64) -> u64 {
     let mut carry = 0;
     for lhs in lhs {
-        (*lhs, carry) = u128::muladd(*lhs, a, carry).split();
+        (*lhs, carry) = DW::split(DW::muladd(*lhs, a, carry));
     }
     carry
 }
@@ -152,7 +152,7 @@ pub fn addmul_nx1(lhs: &mut [u64], a: &[u64], b: u64) -> u64 {
     assume!(lhs.len() == a.len());
     let mut carry = 0;
     for i in 0..a.len() {
-        (lhs[i], carry) = u128::muladd2(a[i], b, carry, lhs[i]).split();
+        (lhs[i], carry) = DW::split(DW::muladd2(a[i], b, carry, lhs[i]));
     }
     carry
 }
@@ -176,7 +176,7 @@ pub fn submul_nx1(lhs: &mut [u64], a: &[u64], b: u64) -> u64 {
     for i in 0..a.len() {
         // Compute product limbs
         let limb;
-        (limb, carry) = u128::muladd(a[i], b, carry).split();
+        (limb, carry) = DW::split(DW::muladd(a[i], b, carry));
 
         // Subtract
         (lhs[i], borrow) = borrowing_sub(lhs[i], limb, borrow);

--- a/src/algorithms/mul_redc.rs
+++ b/src/algorithms/mul_redc.rs
@@ -1,6 +1,6 @@
 // TODO: https://baincapitalcrypto.com/optimizing-montgomery-multiplication-in-webassembly/
 
-use super::{DoubleWord, borrowing_sub, carrying_add, cmp};
+use super::{DW, borrowing_sub, carrying_add, cmp};
 use crate::utils::select_unpredictable;
 use core::{cmp::Ordering, iter::zip};
 
@@ -150,7 +150,7 @@ fn sub<const N: usize>(lhs: [u64; N], rhs: [u64; N]) -> ([u64; N], bool) {
 #[must_use]
 #[allow(clippy::cast_possible_truncation)]
 fn carrying_mul_add(lhs: u64, rhs: u64, add: u64, carry: u64) -> (u64, u64) {
-    u128::muladd2(lhs, rhs, add, carry).split()
+    DW::split(DW::muladd2(lhs, rhs, add, carry))
 }
 
 /// Compute `2 * lhs * rhs + add + carry_lo + 2^64 * carry_hi`.

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::missing_inline_in_public_items)] // allow format functions
 
-use crate::{Uint, algorithms::DoubleWord, base_convert::BaseConvertError};
+use crate::{Uint, algorithms::DW, base_convert::BaseConvertError};
 use core::{fmt, str::FromStr};
 
 /// Error for [`from_str_radix`](Uint::from_str_radix).
@@ -213,7 +213,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     fn muladd_limbs(limbs: &mut [u64; LIMBS], factor: u64, addend: u64) -> Result<(), ParseError> {
         let mut carry = addend;
         for limb in limbs.iter_mut() {
-            (*limb, carry) = u128::muladd(*limb, factor, carry).split();
+            (*limb, carry) = DW::split(DW::muladd(*limb, factor, carry));
         }
         if carry > 0 || (LIMBS != 0 && limbs[LIMBS - 1] > Self::MASK) {
             return Err(BaseConvertError::Overflow.into());


### PR DESCRIPTION
Replaces the DoubleWord trait implementation with a small DW helper namespace. This keeps widened limb operations centralized without implementing extension methods on primitive integer types, and preserves the nightly carrying_mul_add path behind the existing feature gate.

Full stack:
- #589 refactor: replace double word trait, targeting main.
- #590 feat: make mul fns const, targeting dani/dw-helper.
- #591 feat: make from_str_radix const, targeting dani/const-mul-fns.
