### PR TITLE
feat: add strict_* operations

### DIFF
--- a/src/add.rs
+++ b/src/add.rs
@@ -31,6 +31,22 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         }
     }
 
+    /// Computes `self + rhs`, panicking if overflow occurred.
+    ///
+    /// # Panics
+    ///
+    /// This function will always panic on overflow, regardless of whether
+    /// overflow checks are enabled.
+    #[inline(always)]
+    #[must_use]
+    #[track_caller]
+    pub const fn strict_add(self, rhs: Self) -> Self {
+        match self.overflowing_add(rhs) {
+            (value, false) => value,
+            _ => panic!("attempt to add with overflow"),
+        }
+    }
+
     /// Computes `-self`, returning [`None`] unless `self == 0`.
     #[inline(always)]
     #[must_use]
@@ -41,6 +57,22 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         }
     }
 
+    /// Computes `-self`, panicking unless `self == 0`.
+    ///
+    /// # Panics
+    ///
+    /// This function will always panic on overflow, regardless of whether
+    /// overflow checks are enabled.
+    #[inline(always)]
+    #[must_use]
+    #[track_caller]
+    pub const fn strict_neg(self) -> Self {
+        match self.overflowing_neg() {
+            (value, false) => value,
+            _ => panic!("attempt to negate with overflow"),
+        }
+    }
+
     /// Computes `self - rhs`, returning [`None`] if overflow occurred.
     #[inline(always)]
     #[must_use]
@@ -48,6 +80,22 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         match self.overflowing_sub(rhs) {
             (value, false) => Some(value),
             _ => None,
+        }
+    }
+
+    /// Computes `self - rhs`, panicking if overflow occurred.
+    ///
+    /// # Panics
+    ///
+    /// This function will always panic on overflow, regardless of whether
+    /// overflow checks are enabled.
+    #[inline(always)]
+    #[must_use]
+    #[track_caller]
+    pub const fn strict_sub(self, rhs: Self) -> Self {
+        match self.overflowing_sub(rhs) {
+            (value, false) => value,
+            _ => panic!("attempt to subtract with overflow"),
         }
     }
 
@@ -247,5 +295,31 @@ mod tests {
                 assert_eq!(-(-a), a);
             });
         });
+    }
+
+    #[test]
+    fn test_strict_add_sub_neg_ok() {
+        use crate::aliases::U64;
+        assert_eq!(U64::from(1u64).strict_add(U64::from(2u64)), U64::from(3u64));
+        assert_eq!(U64::from(3u64).strict_sub(U64::from(1u64)), U64::from(2u64));
+        assert_eq!(U64::ZERO.strict_neg(), U64::ZERO);
+    }
+
+    #[test]
+    #[should_panic(expected = "attempt to add with overflow")]
+    fn test_strict_add_overflow() {
+        let _ = crate::aliases::U64::MAX.strict_add(crate::aliases::U64::from(1u64));
+    }
+
+    #[test]
+    #[should_panic(expected = "attempt to subtract with overflow")]
+    fn test_strict_sub_overflow() {
+        let _ = crate::aliases::U64::ZERO.strict_sub(crate::aliases::U64::from(1u64));
+    }
+
+    #[test]
+    #[should_panic(expected = "attempt to negate with overflow")]
+    fn test_strict_neg_overflow() {
+        let _ = crate::aliases::U64::from(1u64).strict_neg();
     }
 }

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -347,6 +347,26 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         }
     }
 
+    /// Left shift by `rhs` bits, panicking if the bits shifted out are
+    /// non-zero.
+    ///
+    /// Note: This differs from [`u64::strict_shl`] which panics if the shift is
+    /// larger than `BITS`.
+    ///
+    /// # Panics
+    ///
+    /// This function will always panic on overflow, regardless of whether
+    /// overflow checks are enabled.
+    #[inline(always)]
+    #[must_use]
+    #[track_caller]
+    pub const fn strict_shl(self, rhs: usize) -> Self {
+        match self.overflowing_shl(rhs) {
+            (value, false) => value,
+            _ => panic!("attempt to shift left with overflow"),
+        }
+    }
+
     /// Saturating left shift by `rhs` bits.
     ///
     /// Returns $\mathtt{self} ⋅ 2^{\mathtt{rhs}}$ or [`Uint::MAX`] if the
@@ -467,6 +487,26 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         match self.overflowing_shr(rhs) {
             (value, false) => Some(value),
             _ => None,
+        }
+    }
+
+    /// Right shift by `rhs` bits, panicking if the bits shifted out are
+    /// non-zero.
+    ///
+    /// Note: This differs from [`u64::strict_shr`] which panics if the shift is
+    /// larger than `BITS`.
+    ///
+    /// # Panics
+    ///
+    /// This function will always panic on overflow, regardless of whether
+    /// overflow checks are enabled.
+    #[inline(always)]
+    #[must_use]
+    #[track_caller]
+    pub const fn strict_shr(self, rhs: usize) -> Self {
+        match self.overflowing_shr(rhs) {
+            (value, false) => value,
+            _ => panic!("attempt to shift right with overflow"),
         }
     }
 
@@ -1237,5 +1277,24 @@ mod tests {
                 true
             )
         );
+    }
+
+    #[test]
+    fn test_strict_shl_shr_ok() {
+        use crate::aliases::U64;
+        assert_eq!(U64::from(1u64).strict_shl(3), U64::from(8u64));
+        assert_eq!(U64::from(8u64).strict_shr(3), U64::from(1u64));
+    }
+
+    #[test]
+    #[should_panic(expected = "attempt to shift left with overflow")]
+    fn test_strict_shl_overflow() {
+        let _ = crate::aliases::U64::MAX.strict_shl(1);
+    }
+
+    #[test]
+    #[should_panic(expected = "attempt to shift right with overflow")]
+    fn test_strict_shr_overflow() {
+        let _ = crate::aliases::U64::from(1u64).strict_shr(1);
     }
 }

--- a/src/div.rs
+++ b/src/div.rs
@@ -13,6 +13,22 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         Some(self.div(rhs))
     }
 
+    /// Computes `self / rhs`.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `rhs == 0`.
+    #[inline]
+    #[must_use]
+    #[track_caller]
+    #[allow(clippy::missing_const_for_fn)] // False positive
+    pub fn strict_div(self, rhs: Self) -> Self {
+        match self.checked_div(rhs) {
+            Some(value) => value,
+            None => panic!("attempt to divide by zero"),
+        }
+    }
+
     /// Computes `self % rhs`, returning [`None`] if `rhs == 0`.
     #[inline]
     #[must_use]
@@ -22,6 +38,22 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
             return None;
         }
         Some(self.rem(rhs))
+    }
+
+    /// Computes `self % rhs`.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `rhs == 0`.
+    #[inline]
+    #[must_use]
+    #[track_caller]
+    #[allow(clippy::missing_const_for_fn)] // False positive
+    pub fn strict_rem(self, rhs: Self) -> Self {
+        match self.checked_rem(rhs) {
+            Some(value) => value,
+            None => panic!("attempt to calculate the remainder with a divisor of zero"),
+        }
     }
 
     /// Computes `self / rhs` rounding up.
@@ -145,5 +177,24 @@ mod tests {
                 assert_eq!(q * d + r, n);
             });
         });
+    }
+
+    #[test]
+    fn test_strict_div_rem_ok() {
+        use crate::aliases::U64;
+        assert_eq!(U64::from(7u64).strict_div(U64::from(2u64)), U64::from(3u64));
+        assert_eq!(U64::from(7u64).strict_rem(U64::from(2u64)), U64::from(1u64));
+    }
+
+    #[test]
+    #[should_panic(expected = "attempt to divide by zero")]
+    fn test_strict_div_by_zero() {
+        let _ = crate::aliases::U64::from(1u64).strict_div(crate::aliases::U64::ZERO);
+    }
+
+    #[test]
+    #[should_panic(expected = "attempt to calculate the remainder with a divisor of zero")]
+    fn test_strict_rem_by_zero() {
+        let _ = crate::aliases::U64::from(1u64).strict_rem(crate::aliases::U64::ZERO);
     }
 }

--- a/src/mul.rs
+++ b/src/mul.rs
@@ -16,6 +16,22 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         }
     }
 
+    /// Computes `self * rhs`, panicking if overflow occurred.
+    ///
+    /// # Panics
+    ///
+    /// This function will always panic on overflow, regardless of whether
+    /// overflow checks are enabled.
+    #[inline(always)]
+    #[must_use]
+    #[track_caller]
+    pub const fn strict_mul(self, rhs: Self) -> Self {
+        match self.overflowing_mul(rhs) {
+            (value, false) => value,
+            _ => panic!("attempt to multiply with overflow"),
+        }
+    }
+
     /// Calculates the multiplication of self and rhs.
     ///
     /// Returns a tuple of the multiplication along with a boolean indicating
@@ -286,5 +302,20 @@ mod tests {
                 });
             });
         });
+    }
+
+    #[test]
+    fn test_strict_mul_ok() {
+        use crate::aliases::U64;
+        assert_eq!(
+            U64::from(3u64).strict_mul(U64::from(4u64)),
+            U64::from(12u64)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "attempt to multiply with overflow")]
+    fn test_strict_mul_overflow() {
+        let _ = crate::aliases::U64::MAX.strict_mul(crate::aliases::U64::from(2u64));
     }
 }

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -13,6 +13,22 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         }
     }
 
+    /// Raises self to the power of `exp`, panicking if overflow occurred.
+    ///
+    /// # Panics
+    ///
+    /// This function will always panic on overflow, regardless of whether
+    /// overflow checks are enabled.
+    #[inline]
+    #[must_use]
+    #[track_caller]
+    pub fn strict_pow(self, exp: Self) -> Self {
+        match self.overflowing_pow(exp) {
+            (x, false) => x,
+            (_, true) => panic!("attempt to multiply with overflow"),
+        }
+    }
+
     /// Raises self to the power of `exp` and if the result would overflow.
     ///
     /// # Examples
@@ -206,5 +222,20 @@ mod tests {
                 assert_eq!(b.pow(U::from(e)), prod);
             });
         });
+    }
+
+    #[test]
+    fn test_strict_pow_ok() {
+        use crate::aliases::U64;
+        assert_eq!(
+            U64::from(2u64).strict_pow(U64::from(10u64)),
+            U64::from(1024u64)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "attempt to multiply with overflow")]
+    fn test_strict_pow_overflow() {
+        let _ = crate::aliases::U64::MAX.strict_pow(crate::aliases::U64::from(2u64));
     }
 }


### PR DESCRIPTION
Closes #532

Adds the `strict_*` arithmetic operations to mirror the standard library's (now stabilized) variants. They always panic on overflow, regardless of whether overflow checks are enabled, complementing the existing `checked_*` (returns `Option`), `wrapping_*`, `saturating_*` and `overflowing_*` families.

Added, each next to its `checked_*` counterpart and reusing the existing `overflowing_*` building blocks:

- `strict_add`, `strict_sub`, `strict_neg` (`add.rs`)
- `strict_mul` (`mul.rs`)
- `strict_pow` (`pow.rs`)
- `strict_shl`, `strict_shr` (`bits.rs`)
- `strict_div`, `strict_rem` (`div.rs`)

`const`-ness, `#[inline]`/`#[must_use]` attributes and panic messages follow the standard library and the surrounding code. `strict_shl`/`strict_shr` panic when the shifted-out bits are non-zero, matching ruint's `checked_shl`/`checked_shr` semantics (which intentionally differ from `u64::checked_shl`).

Tests cover the success path and a `#[should_panic]` case per operation, asserting the exact panic message.
