### PR TITLE
chore: ignore cargo-deny advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,13 @@ ignore = [
     { id = "RUSTSEC-2024-0388", reason = "this is an unmaintained transitive subdep of a dev dep" },
     { id = "RUSTSEC-2024-0436", reason = "this is an unmaintained transitive subdep of a dep" },
     { id = "RUSTSEC-2025-0141", reason = "this is an unmaintained dep, but we support it as a feature" },
+    { id = "RUSTSEC-2026-0136", reason = "diesel support does not use COPY FROM or COPY TO APIs" },
+    { id = "RUSTSEC-2026-0137", reason = "diesel support does not use SqliteAggregate" },
+    { id = "RUSTSEC-2026-0176", reason = "pyo3 support does not use the affected list or tuple iterator APIs" },
+    { id = "RUSTSEC-2026-0177", reason = "pyo3 support does not use the affected closure API" },
+    { id = "RUSTSEC-2026-0178", reason = "postgres support only implements type conversions" },
+    { id = "RUSTSEC-2026-0179", reason = "postgres support only implements type conversions" },
+    { id = "RUSTSEC-2026-0180", reason = "postgres support does not use hstore decoding" },
 ]
 
 [bans]


### PR DESCRIPTION
This adds cargo-deny ignores for the current advisory failures in optional feature and dev support crates. The affected PyO3, Diesel, and Postgres APIs are not used by ruint's integration code, and keeping these feature crates pinned avoids forcing version-specific support changes through an advisory-only PR.
