### PR TITLE
fix(ci): harden issue tracker

### DIFF
--- a/.github/scripts/issue_tracker.py
+++ b/.github/scripts/issue_tracker.py
@@ -10,7 +10,7 @@ import json
 import sys
 
 # pip3 install PyGithub numpy
-from github import Github
+from github import Auth, Github
 import numpy as np
 
 # Only actually change things on master
@@ -25,7 +25,7 @@ with os.popen('git rev-parse HEAD') as process:
 print('Commit hash:', commit_hash)
 
 # Connect to the GitHub repo
-gh = Github(os.environ['GITHUB_TOKEN'])
+gh = Github(auth=Auth.Token(os.environ['GITHUB_TOKEN']))
 repo = gh.get_repo(os.environ['REPO_NAME'])
 print('Connected to', repo)
 
@@ -49,6 +49,13 @@ repo_labels = {l.name: l for l in repo.get_labels()}
 
 # Translate users ot PyGitHub `User`s
 users = {k: gh.get_user(v) for k, v in users.items()}
+
+
+def get_github_user(issue):
+    author_mail = issue['author-mail']
+    if author_mail not in users:
+        users[author_mail] = repo.get_commit(issue['commit-hash']).author
+    return users[author_mail]
 
 # Collect existing tracker issues
 open_issues = []
@@ -187,15 +194,16 @@ def render(issue):
     issue = issue.copy()
     issue.pop('open-issue-index', None)
     issue['json'] = json.dumps(issue)
-    issue['github-handle'] = users[issue['author-mail']].login
+    github_user = get_github_user(issue)
+    issue['github-author'] = '@' + github_user.login if github_user else issue['author']
     issue['author-time-pretty'] = date.fromtimestamp(
         issue['author-time']).isoformat()
     issue['commit-hash-short'] = issue['commit-hash'][0:7]
     issue['line-one'] = issue['line'] + 1
-    return dict(
+    result = dict(
         title='{head}'.format(**issue),
         body='''
-*On {author-time-pretty} @{github-handle} wrote in [`{commit-hash-short}`](https://github.com/{repo}/commit/{commit-hash}) “{summary}”:*
+*On {author-time-pretty} {github-author} wrote in [`{commit-hash-short}`](https://github.com/{repo}/commit/{commit-hash}) “{summary}”:*
 
 {issue}
 
@@ -206,9 +214,11 @@ def render(issue):
 
 <!--{json}-->
 '''.strip().format(**issue),
-        assignee=users[issue['author-mail']],
         labels=labels[issue['kind']] + (['blocked'] if 'blocked' in issue else []),
     )
+    if github_user:
+        result['assignee'] = github_user
+    return result
 
 
 def create_issue(source_issue):

--- a/.github/workflows/issue_tracker.yml
+++ b/.github/workflows/issue_tracker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
       - name: Cache Python dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: ~/.cache/pip
           key: issue_tracker-${{ hashFiles('.github/workflows/issue_tracker.yml') }}


### PR DESCRIPTION
The issue tracker workflow was failing when a tracked TODO was blamed to an author email that was not present in the script's static GitHub user map. Instead of requiring every contributor email to be predeclared, the tracker now resolves unknown authors through the associated GitHub commit metadata and falls back to rendering the author name without an assignee if GitHub cannot resolve an account.

This also updates the PyGithub token construction to the current API and moves the cache action to the current Node 24 major, removing the adjacent deprecation warnings from the failed workflow log.

Related run: https://github.com/alloy-rs/ruint/actions/runs/28092061507/job/83172245473
