### PR TITLE
fix: try_from_*_slice returns None instead of panicking for BITS % 64 in 57..=63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `try_from_be_slice`/`try_from_le_slice` now return `None` instead of panicking for `BITS % 64` in `57..=63` ([#607])
+
+[#607]: https://github.com/alloy-rs/ruint/pull/607
+
 ## [1.19.0] - 2026-07-03
 
 ### Added

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -241,7 +241,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
             return None;
         }
 
-        if Self::BYTES % 8 == 0 && bytes.len() == Self::BYTES {
+        if Self::BITS % 64 == 0 && bytes.len() == Self::BYTES {
             // Optimized implementation for full-limb types.
             let mut limbs = [0; LIMBS];
             let end = bytes.as_ptr_range().end;
@@ -315,7 +315,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
             return None;
         }
 
-        if Self::BYTES % 8 == 0 && bytes.len() == Self::BYTES {
+        if Self::BITS % 64 == 0 && bytes.len() == Self::BYTES {
             // Optimized implementation for full-limb types.
             let mut limbs = [0; LIMBS];
             const_range_for!(i in 0..LIMBS => {
@@ -580,6 +580,27 @@ mod tests {
         assert_eq!(
             Uint::<72, 2>::try_from_le_slice(&[&KLE[..], &[0xff]].concat()),
             None
+        );
+    }
+
+    #[test]
+    fn test_from_slice_too_large_returns_none() {
+        // Regression: `BITS % 64` in 57..=63 gives `BYTES = 8 * LIMBS`, so the
+        // full-limb fast path was taken even though the top limb is masked.
+        // An all-ones input overflows the mask and must return `None`, not panic.
+        assert_eq!(Uint::<60, 1>::try_from_be_slice(&[0xff; 8]), None);
+        assert_eq!(Uint::<60, 1>::try_from_le_slice(&[0xff; 8]), None);
+        assert_eq!(Uint::<121, 2>::try_from_be_slice(&[0xff; 16]), None);
+        assert_eq!(Uint::<121, 2>::try_from_le_slice(&[0xff; 16]), None);
+
+        // Values that do fit must still be accepted on this fast path.
+        assert_eq!(
+            Uint::<60, 1>::try_from_be_slice(&[0x0f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+            Some(Uint::<60, 1>::from(0x0fff_ffff_ffff_ffff_u64))
+        );
+        assert_eq!(
+            Uint::<60, 1>::try_from_le_slice(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x0f]),
+            Some(Uint::<60, 1>::from(0x0fff_ffff_ffff_ffff_u64))
         );
     }
 


### PR DESCRIPTION
## Problem

`try_from_be_slice` / `try_from_le_slice` are documented to return `None` when the value is larger than fits the `Uint`. Instead, they panic for a range of bit-sizes:

```rust
Uint::<60, 1>::try_from_be_slice(&[0xff; 8]);   // panics "Value too large for this Uint"
Uint::<121, 2>::try_from_le_slice(&[0xff; 16]); // panics
```

## Root cause

The full-limb fast path was gated on `Self::BYTES % 8 == 0`. Because `BYTES = ceil(BITS / 8)`, that condition is also true for non-limb-aligned sizes whose byte count happens to be a multiple of 8 — `BITS % 64` in `57..=63` gives `BYTES = 8 * LIMBS`. On that path limbs are built directly from the bytes and passed to `from_limbs` **without** the `limbs[LIMBS - 1] > MASK` range check, so an out-of-range value hits `from_limbs`' always-on assert (`src/lib.rs:238`) and panics.

## Fix

Gate the fast path on `Self::BITS % 64 == 0` instead. This is a strict subset of the old condition — true exactly when the top limb is fully used (`MASK == u64::MAX`), so no mask check is needed and reading `LIMBS` full `u64`s stays sound. Previously-mis-gated sizes now fall through to the general path, which performs the mask check and correctly returns `None`.

## Testing

Added `test_from_slice_too_large_returns_none` covering both reported cases (BE + LE, `Uint::<60,1>` and `Uint::<121,2>`) plus in-range values on the same fast path. Verified it panics before the fix and passes after. Full lib suite (139 tests) passes; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)