### PR TITLE
fix: str radix errors now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `from_str_radix` and `to_base_be` no longer hang or silently accept radix/base 0 or 1 ([#608])
+
+[#608]: https://github.com/alloy-rs/ruint/pull/608
+
 ## [1.19.0] - 2026-07-03
 
 ### Added

--- a/src/base_convert.rs
+++ b/src/base_convert.rs
@@ -517,13 +517,17 @@ mod tests {
     #[test]
     #[should_panic = "assertion failed: base > 1"]
     fn test_to_base_be_2_base_0_panics() {
-        let _ = Uint::<64, 1>::from(5u64).to_base_be_2(0).collect::<Vec<_>>();
+        let _ = Uint::<64, 1>::from(5u64)
+            .to_base_be_2(0)
+            .collect::<Vec<_>>();
     }
 
     #[test]
     #[should_panic = "assertion failed: base > 1"]
     fn test_to_base_be_2_base_1_panics() {
-        let _ = Uint::<64, 1>::from(5u64).to_base_be_2(1).collect::<Vec<_>>();
+        let _ = Uint::<64, 1>::from(5u64)
+            .to_base_be_2(1)
+            .collect::<Vec<_>>();
     }
 
     #[test]

--- a/src/base_convert.rs
+++ b/src/base_convert.rs
@@ -389,6 +389,8 @@ impl<const LIMBS: usize> SpigotBuf<LIMBS> {
     #[inline]
     #[track_caller]
     fn new(limbs: [u64; LIMBS], mut base: u64) -> Self {
+        assert!(base > 1);
+
         // We need to do this so we can guarantee that `buf` is big enough.
         base = crate::utils::max_pow_u64(base);
 
@@ -510,6 +512,18 @@ mod tests {
                 2372330524102404852
             ]
         );
+    }
+
+    #[test]
+    #[should_panic = "assertion failed: base > 1"]
+    fn test_to_base_be_2_base_0_panics() {
+        let _ = Uint::<64, 1>::from(5u64).to_base_be_2(0).collect::<Vec<_>>();
+    }
+
+    #[test]
+    #[should_panic = "assertion failed: base > 1"]
+    fn test_to_base_be_2_base_1_panics() {
+        let _ = Uint::<64, 1>::from(5u64).to_base_be_2(1).collect::<Vec<_>>();
     }
 
     #[test]

--- a/src/string.rs
+++ b/src/string.rs
@@ -145,7 +145,11 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// Power-of-2 radix: shift digits directly into limbs, no multiplication.
     #[inline]
     const fn from_str_radix_pow2(src: &str, radix: u64) -> Result<Self, ParseError> {
-        debug_assert!(radix.is_power_of_two());
+        // This catches the case where radix is 1.
+        if radix < 2 {
+            return Err(ParseError::InvalidRadix(radix));
+        }
+
         let bits_per_digit = radix.trailing_zeros() as usize;
         let mut result = Self::ZERO;
         let mut total_bits = 0usize;
@@ -299,6 +303,12 @@ mod tests {
     fn test_from_str_radix_errors() {
         assert!(U8::from_str_radix("...", 0).is_err());
         assert!(U8::from_str_radix("...", 1).is_err());
+        // Radix 1 is a power of two, so this exercises `from_str_radix_pow2`
+        // directly rather than tripping over an invalid digit first.
+        assert_eq!(
+            U8::from_str_radix("0", 1),
+            Err(ParseError::InvalidRadix(1))
+        );
     }
 
     #[test]

--- a/src/string.rs
+++ b/src/string.rs
@@ -46,8 +46,10 @@ impl fmt::Display for ParseError {
 
 /// Returns `(base, power)` where `base = radix^power` is the largest power of
 /// `radix` that fits in a `u64`.
-const fn radix_base(radix: u64) -> (u64, usize) {
-    debug_assert!(radix >= 2);
+const fn radix_base(radix: u64) -> Option<(u64, usize)> {
+    if radix < 2 {
+        return None;
+    }
     let mut power: usize = 1;
     let mut base = radix;
     loop {
@@ -56,7 +58,7 @@ const fn radix_base(radix: u64) -> (u64, usize) {
                 base = n;
                 power += 1;
             }
-            None => return (base, power),
+            None => return Some((base, power)),
         }
     }
 }
@@ -184,7 +186,9 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     #[allow(clippy::cast_possible_truncation)]
     #[inline]
     const fn from_str_radix_chunked(src: &str, radix: u64) -> Result<Self, ParseError> {
-        let (base, power) = radix_base(radix);
+        let Some((base, power)) = radix_base(radix) else {
+            return Err(ParseError::InvalidRadix(radix));
+        };
         let mut result = Self::ZERO;
         let mut chunk_val: u64 = 0;
         let mut chunk_digits: usize = 0;
@@ -257,6 +261,8 @@ impl<const BITS: usize, const LIMBS: usize> FromStr for Uint<BITS, LIMBS> {
 
 #[cfg(test)]
 mod tests {
+    use crate::aliases::U8;
+
     use super::*;
     use proptest::{prop_assert_eq, proptest};
 
@@ -287,6 +293,12 @@ mod tests {
                 _ => panic!(),
             }
         }
+    }
+
+    #[test]
+    fn test_from_str_radix_errors() {
+        assert!(U8::from_str_radix("...", 0).is_err());
+        assert!(U8::from_str_radix("...", 1).is_err());
     }
 
     #[test]

--- a/src/string.rs
+++ b/src/string.rs
@@ -305,10 +305,7 @@ mod tests {
         assert!(U8::from_str_radix("...", 1).is_err());
         // Radix 1 is a power of two, so this exercises `from_str_radix_pow2`
         // directly rather than tripping over an invalid digit first.
-        assert_eq!(
-            U8::from_str_radix("0", 1),
-            Err(ParseError::InvalidRadix(1))
-        );
+        assert_eq!(U8::from_str_radix("0", 1), Err(ParseError::InvalidRadix(1)));
     }
 
     #[test]


### PR DESCRIPTION
Fixes bugs where in release mode radix/base 0 or 1 would hang or be silently accepted and do weird things, in both string parsing and base conversion:

- `from_str_radix`: radix 0 hung inside `radix_base`'s loop (no overflow check terminates it); radix 1 is a power of two, so it bypassed that fix entirely and was silently accepted by `from_str_radix_pow2`, parsing e.g. `"0"` as `0` instead of erroring.
- `to_base_be_2`: base 0 or 1 hung inside `max_pow_u64_impl`, called before `SpigotBuf::new` ever reached the `assert!(base > 1)` that already protects the other spigot paths.

Perf impact should be negligible — each is a single branch on the already-cold/rarely-taken invalid-input path.