### PR TITLE
fix: checked_log/log2/log10 panic on tiny bit-widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `checked_log`, `checked_log2`, and `checked_log10` no longer panic for small bit-widths where the base constant does not fit the type ([#610])
+
+[#610]: https://github.com/alloy-rs/ruint/pull/610
+
 ## [1.19.0] - 2026-07-03
 
 ### Added

--- a/src/log.rs
+++ b/src/log.rs
@@ -9,7 +9,9 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     #[inline]
     #[must_use]
     pub fn checked_log(self, base: Self) -> Option<usize> {
-        if base < Self::from(2) || self.is_zero() {
+        // `base < 2` is `base <= 1`, which avoids materializing `2` with the
+        // panicking `Self::from` — `2` does not fit when `BITS < 2`.
+        if base <= Self::ONE || self.is_zero() {
             return None;
         }
         Some(self.log(base))
@@ -21,7 +23,15 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     #[inline]
     #[must_use]
     pub fn checked_log10(self) -> Option<usize> {
-        self.checked_log(Self::from(10))
+        if self.is_zero() {
+            return None;
+        }
+        match Self::try_from(10u64) {
+            Ok(base) => Some(self.log(base)),
+            // `10` does not fit (`BITS < 4`), so every representable value is
+            // strictly less than `10` and its base-10 logarithm is `0`.
+            Err(_) => Some(0),
+        }
     }
 
     /// Returns the base 2 logarithm of the number, rounded down.
@@ -32,7 +42,12 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     #[inline]
     #[must_use]
     pub fn checked_log2(self) -> Option<usize> {
-        self.checked_log(Self::from(2))
+        if self.is_zero() {
+            return None;
+        }
+        // The base-2 logarithm is the index of the highest set bit. Computing it
+        // directly avoids materializing `2`, which does not fit when `BITS < 2`.
+        Some(self.bit_len() - 1)
     }
 
     /// Returns the logarithm of the number, rounded down.
@@ -167,6 +182,34 @@ mod tests {
         assert_eq!(U128::from(3).checked_log2(), Some(1));
         assert_eq!(U128::from(127).checked_log2(), Some(6));
         assert_eq!(U128::from(128).checked_log2(), Some(7));
+    }
+
+    #[test]
+    fn test_checked_log_tiny_bits() {
+        // The `checked_*` variants return an `Option` and must never panic, even
+        // when the base constant (2 or 10) is too large for the bit-width.
+
+        // BITS < 2: the type cannot represent 2.
+        assert_eq!(Uint::<0, 0>::ZERO.checked_log2(), None);
+        assert_eq!(Uint::<1, 1>::ZERO.checked_log2(), None);
+        assert_eq!(Uint::<1, 1>::from(1u64).checked_log2(), Some(0));
+
+        // `checked_log` with a base that is 0 or 1 (all bases fit in `Uint<1, 1>`)
+        // returns None rather than panicking on `Self::from(2)`.
+        let one = Uint::<1, 1>::from(1u64);
+        assert_eq!(Uint::<1, 1>::ZERO.checked_log(one), None);
+        assert_eq!(one.checked_log(one), None);
+        assert_eq!(one.checked_log(Uint::<1, 1>::ZERO), None);
+
+        // BITS < 4: the type cannot represent 10. Every representable value is
+        // therefore < 10, so the base-10 logarithm of any nonzero value is 0.
+        assert_eq!(Uint::<2, 1>::ZERO.checked_log10(), None);
+        assert_eq!(Uint::<2, 1>::from(3u64).checked_log10(), Some(0));
+        assert_eq!(Uint::<3, 1>::from(7u64).checked_log10(), Some(0));
+
+        // BITS == 4: 10 fits, so the normal path is taken and boundaries hold.
+        assert_eq!(Uint::<4, 1>::from(9u64).checked_log10(), Some(0));
+        assert_eq!(Uint::<4, 1>::from(15u64).checked_log10(), Some(1));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The `checked_*` logarithm methods are documented to return an `Option` and never panic ("Returns `None` if the base is less than two, or this number is zero"). But each materialized its comparison/base constant with the **panicking** `Uint::from`:

- `checked_log` — `base < Self::from(2)`
- `checked_log2` — `checked_log(Self::from(2))`
- `checked_log10` — `checked_log(Self::from(10))`

The constant `2` overflows the type itself when `BITS < 2`, and `10` when `BITS < 4`, so the panic fires *before* any `None` can be returned:

```rust
Uint::<1, 1>::from(1u64).checked_log2();                       // panicked: "Value is too large for Uint<1>"
Uint::<1, 1>::ZERO.checked_log(Uint::<1, 1>::from(1u64));      // panicked
Uint::<2, 1>::from(3u64).checked_log10();                      // panicked (should be Some(0): 10^0 = 1 <= 3)
```

## Fix

- **`checked_log`** compares `base` against `Self::ONE` (`base <= 1` ⟺ `base < 2`) instead of `Self::from(2)`. `Self::ONE` saturates to `0` for `BITS == 0`, so the comparison is exactly equivalent and never panics.
- **`checked_log2`** returns `bit_len() - 1` directly (the index of the highest set bit — the documented definition), never materializing `2`.
- **`checked_log10`** constructs `10` with the fallible `try_from`. When `10` doesn't fit the type, every representable value is `< 10`, so `floor(log10)` of any nonzero value is `0` — which is the mathematically correct result, not `None`.

The panicking `log`/`log2`/`log10` variants are unchanged (they are documented to panic).

## Testing

Added `test_checked_log_tiny_bits` covering `BITS` of 0, 1, 2, 3, and the `BITS == 4` boundary where `10` first fits. All existing tests and clippy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)