### PR TITLE
docs: fix incorrect comments in add/mul/gcd algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix incorrect doc comments and formulas in the `add`, `mul`, and `gcd` algorithms ([#611])
+
+[#611]: https://github.com/alloy-rs/ruint/pull/611
+
 ## [1.19.0] - 2026-07-03
 
 ### Added

--- a/src/algorithms/add.rs
+++ b/src/algorithms/add.rs
@@ -45,7 +45,7 @@ pub fn carrying_add_n(lhs: &mut [u64], rhs: &[u64], mut carry: bool) -> bool {
     carry
 }
 
-/// ⚠️ `lhs -= rhs - borrow`
+/// ⚠️ `lhs -= rhs + borrow`
 #[doc = crate::algorithms::unstable_warning!()]
 #[inline(always)]
 pub fn borrowing_sub_n(lhs: &mut [u64], rhs: &[u64], mut borrow: bool) -> bool {

--- a/src/algorithms/gcd/matrix.rs
+++ b/src/algorithms/gcd/matrix.rs
@@ -256,10 +256,10 @@ impl Matrix {
         // Use Jebelean's exact condition to determine which outputs are correct.
         // Statistically, i + 2 should be correct about two-thirds of the time.
         if even {
-            // Test i + 1 (odd)
+            // Test i + 1 (even)
             debug_assert!(a2 >= v2);
             if a1 - a2 >= u2 + u1 {
-                // Test i + 2 (even)
+                // Test i + 2 (odd)
                 if a3 >= u3 && a2 - a3 >= v3 + v2 {
                     // Correct value is i + 2
                     Matrix(u2, v2, u3, v3, true)
@@ -272,10 +272,10 @@ impl Matrix {
                 Matrix(u0, v0, u1, v1, true)
             }
         } else {
-            // Test i + 1 (even)
+            // Test i + 1 (odd)
             debug_assert!(a2 >= u2);
             if a1 - a2 >= v2 + v1 {
-                // Test i + 2 (odd)
+                // Test i + 2 (even)
                 if a3 >= v3 && a2 - a3 >= u3 + u2 {
                     // Correct value is i + 2
                     Matrix(u2, v2, u3, v3, false)

--- a/src/algorithms/mul.rs
+++ b/src/algorithms/mul.rs
@@ -165,7 +165,7 @@ pub const fn addmul_nx1(lhs: &mut [u64], a: &[u64], b: u64) -> u64 {
 /// $$
 /// \begin{aligned}
 /// \mathsf{lhs'} &= \mod{\mathsf{lhs} - \mathsf{a} ⋅ \mathsf{b}}_{2^{64⋅N}}
-/// \\\\ \mathsf{borrow} &= \floor{\frac{\mathsf{a} ⋅ \mathsf{b} -
+/// \\\\ \mathsf{borrow} &= \ceil{\frac{\mathsf{a} ⋅ \mathsf{b} -
 /// \mathsf{lhs}}{2^{64⋅N}}} \end{aligned}
 /// $$
 // OPT: `carry` and `borrow` can probably be merged into a single var.


### PR DESCRIPTION
Fixes three documentation-only defects where comments/formulas contradicted the (correct) code.

| Location | Before | After |
| --- | --- | --- |
| `src/algorithms/add.rs:48` | `borrowing_sub_n` doc: `lhs -= rhs - borrow` | `lhs -= rhs + borrow` — matches per-limb `lhs[i] - rhs[i] - borrow` |
| `src/algorithms/mul.rs:168` | `submul_nx1` borrow = `⌊(a·b − lhs)/2^(64N)⌋` | `⌈(a·b − lhs)/2^(64N)⌉` — e.g. `lhs=[3]`, `a=[5]`, `b=1` returns borrow `1`, floor gives `0` |
| `src/algorithms/gcd/matrix.rs:259,262,275,288` | `(odd)`/`(even)` labels swapped vs. the returned parity flag | labels aligned (flag `false` = even index) |

No behavioral changes — comments and one KaTeX formula only. The Jebelean stopping conditions themselves are unchanged.

Docs verified to build without warnings:
```
RUSTDOCFLAGS="--cfg docsrs --html-in-header .cargo/katex-header.html -D warnings" \
  cargo +nightly doc --no-deps --all-features
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)