### PR TITLE
fix(algorithms): close soundness and safety-contract gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Mark `addmul_nx1`/`submul_nx1` `unsafe` and close soundness / safety-contract gaps in the unstable `algorithms` module ([#612])
+
+[#612]: https://github.com/alloy-rs/ruint/pull/612
+
 ## [1.19.0] - 2026-07-03
 
 ### Added

--- a/src/algorithms/div/knuth.rs
+++ b/src/algorithms/div/knuth.rs
@@ -13,7 +13,12 @@ use crate::{
 ///
 /// - The highest (most-significant) bit of the divisor MUST be set.
 /// - The `divisor` and `numerator` MUST each be at least two limbs.
-/// - `numerator` MUST contain at at least as many elements as `divisor`.
+/// - `numerator` MUST contain strictly more limbs than `divisor`; the extra
+///   limb(s) hold the quotient. (Equal lengths are NOT permitted.)
+/// - The quotient MUST fit in `numerator.len() - divisor.len()` limbs; that is,
+///   `numerator / divisor < 2^(64 * (numerator.len() - divisor.len()))`.
+///   Equivalently, the two most-significant limbs of `numerator` MUST NOT
+///   exceed the two most-significant limbs of `divisor`.
 ///
 /// In debug mode, panics if any condition of use is violated. In release, may
 /// panic or trigger UB if any condition of use is violated.
@@ -22,7 +27,7 @@ use crate::{
 #[allow(clippy::many_single_char_names)]
 pub unsafe fn div_nxm_normalized(numerator: &mut [u64], divisor: &[u64]) {
     debug_assert!(divisor.len() >= 2);
-    debug_assert!(numerator.len() >= divisor.len());
+    debug_assert!(numerator.len() > divisor.len());
     debug_assert!(*divisor.last().unwrap() >= (1 << 63));
 
     let numerator = UncheckedSlice::wrap_mut(numerator);
@@ -46,7 +51,8 @@ pub unsafe fn div_nxm_normalized(numerator: &mut [u64], divisor: &[u64]) {
         // Overflow case
         if unlikely(n21 == d) {
             let q = u64::MAX;
-            let _carry = submul_nx1(&mut numerator[j..j + n], divisor, q);
+            // SAFETY: both slices have length `n`.
+            let _carry = unsafe { submul_nx1(&mut numerator[j..j + n], divisor, q) };
             numerator[j + n] = q;
             continue;
         }
@@ -60,7 +66,8 @@ pub unsafe fn div_nxm_normalized(numerator: &mut [u64], divisor: &[u64]) {
         // Subtract the quotient times the divisor from the remainder.
         // We already have the highest two limbs, so we can reduce the
         // computation. We still need to carry propagate into these limbs.
-        let borrow = submul_nx1(&mut numerator[j..j + n - 2], &divisor[..n - 2], q);
+        // SAFETY: both slices have length `n - 2`.
+        let borrow = unsafe { submul_nx1(&mut numerator[j..j + n - 2], &divisor[..n - 2], q) };
         let (r, borrow) = r.overflowing_sub(u128::from(borrow));
         numerator[j + n - 2] = DW::low(r);
         numerator[j + n - 1] = DW::high(r);
@@ -158,7 +165,9 @@ pub unsafe fn div_nxm(numerator: &mut [u64], divisor: &mut [u64]) {
                 // We already have the highest 128 bit, so we can reduce the
                 // computation. We still need to carry propagate into these limbs.
                 let borrow = if shift == 0 {
-                    let borrow = submul_nx1(&mut numerator[j..j + n - 2], &divisor[..n - 2], q);
+                    // SAFETY: both slices have length `n - 2`.
+                    let borrow =
+                        unsafe { submul_nx1(&mut numerator[j..j + n - 2], &divisor[..n - 2], q) };
                     let (r, borrow) = r.overflowing_sub(u128::from(borrow));
                     numerator[j + n - 2] = DW::low(r);
                     numerator[j + n - 1] = DW::high(r);
@@ -167,7 +176,8 @@ pub unsafe fn div_nxm(numerator: &mut [u64], divisor: &mut [u64]) {
                     // OPT: Can we re-use `r` here somehow? The problem is we can not just
                     // shift the `r` or `borrow` because we need to accurately reproduce
                     // the remainder and carry in the middle of a limb.
-                    let borrow = submul_nx1(&mut numerator[j..j + n], divisor, q);
+                    // SAFETY: both slices have length `n`.
+                    let borrow = unsafe { submul_nx1(&mut numerator[j..j + n], divisor, q) };
                     let n2 = numerator.get(j + n).copied().unwrap_or_default();
                     borrow != n2
                 };
@@ -185,7 +195,8 @@ pub unsafe fn div_nxm(numerator: &mut [u64], divisor: &mut [u64]) {
         } else {
             // Overflow case
             let q = u64::MAX;
-            let _carry = submul_nx1(&mut numerator[j..j + n], divisor, q);
+            // SAFETY: both slices have length `n`.
+            let _carry = unsafe { submul_nx1(&mut numerator[j..j + n], divisor, q) };
             q
         };
 

--- a/src/algorithms/mul.rs
+++ b/src/algorithms/mul.rs
@@ -57,7 +57,8 @@ pub const fn addmul(mut lhs: &mut [u64], mut a: &[u64], mut b: &[u64]) -> bool {
     const_range_for!(&b in ref b => {
         if lhs.len() >= a.len() {
             let (target, rest) = lhs.split_at_mut(a.len());
-            let carry = addmul_nx1(target, a, b);
+            // SAFETY: `target` has length `a.len()` from `split_at_mut(a.len())`.
+            let carry = unsafe { addmul_nx1(target, a, b) };
             let carry = add_nx1(rest, carry);
             overflow |= carry != 0;
         } else {
@@ -66,7 +67,8 @@ pub const fn addmul(mut lhs: &mut [u64], mut a: &[u64], mut b: &[u64]) -> bool {
                 break;
             }
             let (a, _) = a.split_at(lhs.len());
-            addmul_nx1(lhs, a, b);
+            // SAFETY: `a` is truncated to `lhs.len()`, so `lhs.len() == a.len()`.
+            unsafe { addmul_nx1(lhs, a, b) };
         }
         (_, lhs) = lhs.split_at_mut(1);
     });
@@ -139,9 +141,14 @@ pub const fn mul_nx1(lhs: &mut [u64], a: u64) -> u64 {
 }
 
 /// ⚠️ Computes `lhs += a * b` and returns the carry.
-#[doc = crate::algorithms::unstable_warning!()]
-/// Requires `lhs.len() == a.len()`.
 ///
+/// # Safety
+///
+/// `lhs.len()` MUST equal `a.len()`.
+///
+/// In debug mode, panics if the condition of use is violated. In release, may
+/// panic or trigger UB if the condition of use is violated.
+#[doc = crate::algorithms::unstable_warning!()]
 /// $$
 /// \begin{aligned}
 /// \mathsf{lhs'} &= \mod{\mathsf{lhs} + \mathsf{a} ⋅ \mathsf{b}}_{2^{64⋅N}}
@@ -149,7 +156,7 @@ pub const fn mul_nx1(lhs: &mut [u64], a: u64) -> u64 {
 /// }{2^{64⋅N}}} \end{aligned}
 /// $$
 #[inline(always)]
-pub const fn addmul_nx1(lhs: &mut [u64], a: &[u64], b: u64) -> u64 {
+pub const unsafe fn addmul_nx1(lhs: &mut [u64], a: &[u64], b: u64) -> u64 {
     assume!(lhs.len() == a.len());
     let mut carry = 0;
     const_range_for!(i in 0..a.len() => {
@@ -159,9 +166,14 @@ pub const fn addmul_nx1(lhs: &mut [u64], a: &[u64], b: u64) -> u64 {
 }
 
 /// ⚠️ Computes `lhs -= a * b` and returns the borrow.
-#[doc = crate::algorithms::unstable_warning!()]
-/// Requires `lhs.len() == a.len()`.
 ///
+/// # Safety
+///
+/// `lhs.len()` MUST equal `a.len()`.
+///
+/// In debug mode, panics if the condition of use is violated. In release, may
+/// panic or trigger UB if the condition of use is violated.
+#[doc = crate::algorithms::unstable_warning!()]
 /// $$
 /// \begin{aligned}
 /// \mathsf{lhs'} &= \mod{\mathsf{lhs} - \mathsf{a} ⋅ \mathsf{b}}_{2^{64⋅N}}
@@ -170,7 +182,7 @@ pub const fn addmul_nx1(lhs: &mut [u64], a: &[u64], b: u64) -> u64 {
 /// $$
 // OPT: `carry` and `borrow` can probably be merged into a single var.
 #[inline(always)]
-pub const fn submul_nx1(lhs: &mut [u64], a: &[u64], b: u64) -> u64 {
+pub const unsafe fn submul_nx1(lhs: &mut [u64], a: &[u64], b: u64) -> u64 {
     assume!(lhs.len() == a.len());
     let mut carry = 0;
     let mut borrow = false;
@@ -277,7 +289,8 @@ mod tests {
             18362433840513668572,
         ];
         let b = 17275533833223164845;
-        let borrow = submul_nx1(&mut lhs, &a, b);
+        // SAFETY: `lhs` and `a` are both length 4.
+        let borrow = unsafe { submul_nx1(&mut lhs, &a, b) };
         assert_eq!(lhs, [
             2427453526388035261,
             7389014268281543265,

--- a/src/base_convert.rs
+++ b/src/base_convert.rs
@@ -158,7 +158,8 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
             }
 
             // Add digit to result
-            let overflow = addmul_nx1(&mut result.limbs, power.as_limbs(), digit);
+            // SAFETY: `result.limbs` and `power.as_limbs()` are both `[u64; LIMBS]`.
+            let overflow = unsafe { addmul_nx1(&mut result.limbs, power.as_limbs(), digit) };
             if overflow != 0 || result.limbs[LIMBS - 1] > Self::MASK {
                 return Err(BaseConvertError::Overflow);
             }


### PR DESCRIPTION
## Summary

Closes three soundness / safety-contract gaps in the (explicitly unstable) `algorithms` module. All were surfaced by security review, empirically reproduced (debug panic + release SIGTRAP / silent truncation), and confirmed reachable only via the public unstable API (in-crate callers already satisfy every precondition).

### `addmul_nx1` / `submul_nx1` — safe-code UB
Both were safe `pub const fn`s executing `assume!(lhs.len() == a.len())`, which lowers to `core::hint::unreachable_unchecked()` in release. A **safe** function must not have UB for any input; on a length mismatch these did (release SIGTRAP; with constant inputs the optimizer even deleted the call site as dead code).

- Marked both `pub const unsafe fn` with a `# Safety` section, matching the existing style of `div_nxm_normalized`.
- Retained `assume!` (now sound, since the caller contractually guarantees the invariant) to preserve the optimization that motivated it.
- Wrapped all 7 in-crate call sites in `unsafe {}` with `// SAFETY:` comments (2 in `addmul`, 1 in `base_convert`, 1 test, 3 in `knuth`). Edition 2024 requires explicit blocks even inside `unsafe fn`.

### `div_nxm_normalized` — equal-length underflow
The `# Safety` docs required only "at least as many elements as divisor", but `numerator.len() - n - 1` underflows when the lengths are **equal** — an input satisfying every documented condition and `debug_assert`. Release: `m = usize::MAX` → out-of-bounds writes.

- Corrected the contract to require **strictly more limbs** than the divisor.
- Tightened `debug_assert!(numerator.len() >= divisor.len())` → `> ` so the invalid case fails with a clear message rather than a downstream "subtract with overflow".

### `div_nxm_normalized` — undocumented "quotient must fit" precondition
The function additionally requires the quotient to fit in `numerator.len() - divisor.len()` limbs (already enforced by `debug_assert!(n21 <= d)`); violating it silently truncates the quotient in release. Documented it in the `# Safety` section.

_No functional finding for `mul_redc`/`square_redc` — their `a,b < modulus` requirement is already documented, so debug-only enforcement is within contract; left unchanged._

## Verification
- No behavior change for valid inputs.
- `cargo test`: 138 lib + 34 doc tests pass.
- `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)