### PR TITLE
perf: unify const_eq/const_is_zero with their runtime equivalents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Run the core test suite on `wasm32-wasip1` in CI to catch 32-bit pointer-width bugs ([#609])
+- Optimize `const_eq`, `const_is_zero`, and `is_zero` to match or beat the derived `PartialEq` / `== ZERO` forms, especially in dependency-chained use ([#615])
 
 ### Fixed
 
@@ -31,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#610]: https://github.com/alloy-rs/ruint/pull/610
 [#611]: https://github.com/alloy-rs/ruint/pull/611
 [#612]: https://github.com/alloy-rs/ruint/pull/612
+[#615]: https://github.com/alloy-rs/ruint/pull/615
 
 ## [1.19.0] - 2026-07-03
 

--- a/benches/benches/cmp.rs
+++ b/benches/benches/cmp.rs
@@ -4,7 +4,11 @@ pub fn group(criterion: &mut Criterion) {
     const_for!(BITS in BENCH {
         const LIMBS: usize = nlimbs(BITS);
         bench_unop::<BITS, LIMBS, _>(criterion, "is_zero", |a| a.is_zero());
+        bench_unop::<BITS, LIMBS, _>(criterion, "const_is_zero", |a| a.const_is_zero());
+        bench_unop::<BITS, LIMBS, _>(criterion, "const_is_zero_dw", |a| a.const_is_zero_dw());
         bench_binop::<BITS, LIMBS, _>(criterion, "eq", |a, b| a == b);
+        bench_binop::<BITS, LIMBS, _>(criterion, "const_eq", |a, b| a.const_eq(&b));
+        bench_binop::<BITS, LIMBS, _>(criterion, "const_eq_dw", |a, b| a.const_eq_dw(&b));
         bench_binop::<BITS, LIMBS, _>(criterion, "cmp", |a, b| a.cmp(&b));
         bench_binop::<BITS, LIMBS, _>(criterion, "lt", |a, b| a < b);
         bench_binop::<BITS, LIMBS, _>(criterion, "gt", |a, b| a > b);

--- a/benches/benches/cmp.rs
+++ b/benches/benches/cmp.rs
@@ -5,10 +5,8 @@ pub fn group(criterion: &mut Criterion) {
         const LIMBS: usize = nlimbs(BITS);
         bench_unop::<BITS, LIMBS, _>(criterion, "is_zero", |a| a.is_zero());
         bench_unop::<BITS, LIMBS, _>(criterion, "const_is_zero", |a| a.const_is_zero());
-        bench_unop::<BITS, LIMBS, _>(criterion, "const_is_zero_dw", |a| a.const_is_zero_dw());
         bench_binop::<BITS, LIMBS, _>(criterion, "eq", |a, b| a == b);
         bench_binop::<BITS, LIMBS, _>(criterion, "const_eq", |a, b| a.const_eq(&b));
-        bench_binop::<BITS, LIMBS, _>(criterion, "const_eq_dw", |a, b| a.const_eq_dw(&b));
         bench_binop::<BITS, LIMBS, _>(criterion, "cmp", |a, b| a.cmp(&b));
         bench_binop::<BITS, LIMBS, _>(criterion, "lt", |a, b| a < b);
         bench_binop::<BITS, LIMBS, _>(criterion, "gt", |a, b| a > b);

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -134,9 +134,9 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// Returns `true` if the value is zero.
     ///
     /// This is equivalent to [`is_zero`](Self::is_zero), usable in `const`
-    /// contexts. With more than `EQ_FOLD_MAX_LIMBS` limbs this may perform
-    /// worse than [`is_zero`](Self::is_zero), which can compare against the
-    /// zero constant with `memcmp`.
+    /// contexts. With more than 16 limbs (1024 bits) this may perform worse
+    /// than [`is_zero`](Self::is_zero), which can compare against the zero
+    /// constant with `memcmp`.
     #[inline]
     #[must_use]
     pub const fn const_is_zero(&self) -> bool {

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -99,14 +99,20 @@ impl_for_primitives!(
 /// limb-counting loop above it. LLVM lowers the fold by context: when the
 /// result feeds a dependency chain and the operands live in registers it
 /// stays scalar (`xor`/`or` on x86-64, `ccmp` flags on aarch64), avoiding
-/// the vector round-trip that stalls dependent use (measured 44% faster
-/// per link than the double-word form on Zen 2 at 256 bits); standalone it
-/// re-vectorizes at 8+ limbs (`pxor`/`ptest` on x86-64, NEON on aarch64).
-/// At 4 limbs x86-64 keeps even the standalone form scalar, costing ~0.3 ns
-/// against `ptest` but still beating the derived `PartialEq`. At high limb
-/// counts the serial forms lose to LLVM's auto-vectorization of the counting
-/// loop (measured cliff at 24 limbs on Zen 2, crossover by 64 limbs on Apple
+/// the vector round-trip that stalls dependent use — reloading the
+/// consumer's 8-byte scalar stores as 16-byte vector loads defeats
+/// store-to-load forwarding (measured 44% faster per link than the
+/// double-word form on Zen 2 at 256 bits); standalone it re-vectorizes at
+/// 8+ limbs (`pxor`/`ptest` on x86-64, NEON on aarch64). At 4 limbs x86-64
+/// keeps even the standalone form scalar, costing ~0.3 ns against `ptest`
+/// but still beating the derived `PartialEq`. At high limb counts the
+/// serial forms lose to LLVM's auto-vectorization of the counting loop
+/// (measured cliff at 24 limbs on Zen 2, crossover by 64 limbs on Apple
 /// M-series).
+///
+/// The win is latency-shaped: instruction-count profiling (e.g. CodSpeed)
+/// is blind to both the stall and the fix, so only wall-clock benchmarks of
+/// dependency-chained use can catch a regression here.
 const EQ_FOLD_MAX_LIMBS: usize = 16;
 
 impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
@@ -128,9 +134,9 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// Returns `true` if the value is zero.
     ///
     /// This is equivalent to [`is_zero`](Self::is_zero), usable in `const`
-    /// contexts. For more than 16 limbs (1024 bits) this may perform worse
-    /// than [`is_zero`](Self::is_zero), which can compare against the zero
-    /// constant with `memcmp`.
+    /// contexts. With more than `EQ_FOLD_MAX_LIMBS` limbs this may perform
+    /// worse than [`is_zero`](Self::is_zero), which can compare against the
+    /// zero constant with `memcmp`.
     #[inline]
     #[must_use]
     pub const fn const_is_zero(&self) -> bool {
@@ -245,12 +251,19 @@ mod tests {
             let b = Uint::<256, 4>::from_limbs([1, 2, 3, 5]);
             let c = Uint::<192, 3>::from_limbs([1, 2, 3]);
             let d = Uint::<192, 3>::from_limbs([1, 2, 4]);
+            // 32 limbs exercises the above-`EQ_FOLD_MAX_LIMBS` fallback
+            // branches (counting loop and OR-fold) in CTFE.
+            type Wide = Uint<2048, 32>;
             a.const_eq(&a)
                 && !a.const_eq(&b)
                 && !a.const_is_zero()
                 && Uint::<256, 4>::ZERO.const_is_zero()
                 && c.const_eq(&c)
                 && !c.const_eq(&d)
+                && Wide::ZERO.const_is_zero()
+                && !Wide::MAX.const_is_zero()
+                && Wide::MAX.const_eq(&Wide::MAX)
+                && !Wide::MAX.const_eq(&Wide::ZERO)
         };
         const { assert!(OK) };
     }
@@ -264,6 +277,19 @@ mod tests {
             assert!(U::ZERO.const_is_zero());
             assert!(U::MAX.const_eq(&U::MAX));
             assert_eq!(U::MAX.const_is_zero(), U::MAX.is_zero());
+            proptest!(|(a: U, b: U)| {
+                prop_assert_eq!(a.const_eq(&b), a == b);
+                prop_assert!(a.const_eq(&a));
+                prop_assert_eq!(a.const_is_zero(), a.is_zero());
+            });
+        });
+        // `SIZES` jumps from 8 to 64 limbs; pin both sides of the
+        // `EQ_FOLD_MAX_LIMBS` cutoff (16 and 17 limbs).
+        const_for!(BITS in [1024, 1088] {
+            const LIMBS: usize = nlimbs(BITS);
+            type U = Uint<BITS, LIMBS>;
+            assert!(U::ZERO.const_is_zero());
+            assert!(U::MAX.const_eq(&U::MAX));
             proptest!(|(a: U, b: U)| {
                 prop_assert_eq!(a.const_eq(&b), a == b);
                 prop_assert!(a.const_eq(&a));

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -137,13 +137,55 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         });
         equal_count == LIMBS
     }
+
+    /// Returns `true` if `self` equals `other`.
+    ///
+    /// Prototype reformulation of [`const_eq`](Self::const_eq) that compares
+    /// double-word (`u128`) chunks instead of counting equal limbs. LLVM
+    /// lowers this to the same code as the derived `PartialEq` (`==`), while
+    /// the limb-counting loop gets auto-vectorized into a horizontal
+    /// reduction with worse dependent-use latency.
+    #[inline]
+    #[must_use]
+    pub const fn const_eq_dw(&self, other: &Self) -> bool {
+        as_primitives!(self, other; {
+            u64(x, y) => return x == y,
+            u128(x, y) => return x == y,
+        });
+        let mut eq = true;
+        if LIMBS >= 2 {
+            let a = self.as_double_words();
+            let b = other.as_double_words();
+            const_range_for!(i in 0..LIMBS / 2 => {
+                eq &= a[i].get() == b[i].get();
+            });
+        }
+        if LIMBS % 2 == 1 {
+            eq &= self.limbs[LIMBS - 1] == other.limbs[LIMBS - 1];
+        }
+        eq
+    }
+
+    /// Returns `true` if the value is zero.
+    ///
+    /// Prototype reformulation of [`const_is_zero`](Self::const_is_zero) on
+    /// top of [`const_eq_dw`](Self::const_eq_dw).
+    #[inline]
+    #[must_use]
+    pub const fn const_is_zero_dw(&self) -> bool {
+        as_primitives!(self; {
+            u64(x) => return x == 0,
+            u128(x) => return x == 0,
+        });
+        self.const_eq_dw(&Self::ZERO)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{Uint, const_for, nlimbs};
     use core::cmp::Ordering;
-    use proptest::{prop_assert_eq, proptest};
+    use proptest::{prop_assert, prop_assert_eq, proptest};
 
     fn reference_cmp<const BITS: usize, const LIMBS: usize>(
         a: &Uint<BITS, LIMBS>,
@@ -192,6 +234,52 @@ mod tests {
             type U = Uint<BITS, LIMBS>;
             proptest!(|(a: U, b: U)| {
                 check_cmp(a, b)?;
+            });
+        });
+    }
+
+    #[test]
+    fn test_const_eq_dw_ctfe() {
+        const OK: bool = {
+            let a = Uint::<256, 4>::from_limbs([1, 2, 3, 4]);
+            let b = Uint::<256, 4>::from_limbs([1, 2, 3, 5]);
+            let c = Uint::<192, 3>::from_limbs([1, 2, 3]);
+            let d = Uint::<192, 3>::from_limbs([1, 2, 4]);
+            a.const_eq_dw(&a)
+                && !a.const_eq_dw(&b)
+                && !a.const_is_zero_dw()
+                && Uint::<256, 4>::ZERO.const_is_zero_dw()
+                && c.const_eq_dw(&c)
+                && !c.const_eq_dw(&d)
+        };
+        const { assert!(OK) };
+    }
+
+    #[test]
+    fn test_const_eq_dw() {
+        const_for!(BITS in SIZES {
+            const LIMBS: usize = nlimbs(BITS);
+            type U = Uint<BITS, LIMBS>;
+            assert!(U::ZERO.const_eq_dw(&U::ZERO));
+            assert!(U::ZERO.const_is_zero_dw());
+            assert!(U::MAX.const_eq_dw(&U::MAX));
+            assert_eq!(U::MAX.const_is_zero_dw(), U::MAX.is_zero());
+            proptest!(|(a: U, b: U)| {
+                prop_assert_eq!(a.const_eq_dw(&b), a == b);
+                prop_assert!(a.const_eq_dw(&a));
+                prop_assert_eq!(a.const_is_zero_dw(), a.is_zero());
+            });
+        });
+        // A difference in any single limb must be detected.
+        const_for!(BITS in NON_ZERO {
+            const LIMBS: usize = nlimbs(BITS);
+            type U = Uint<BITS, LIMBS>;
+            proptest!(|(a: U, limb in 0..LIMBS)| {
+                let mut b = a;
+                // Bit 0 of every limb is always within the mask.
+                unsafe { b.as_limbs_mut()[limb] ^= 1 };
+                prop_assert!(!a.const_eq_dw(&b));
+                prop_assert!(!b.const_eq_dw(&a));
             });
         });
     }

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -95,89 +95,88 @@ impl_for_primitives!(
     i8, i16, i32, i64, i128, isize,
 );
 
+/// `const_eq` compares double-word chunks up to this many limbs, and falls
+/// back to a limb-counting loop above it. The chunked form lowers to the same
+/// code as the derived `PartialEq` (flag chain on aarch64, `pxor`/`ptest` on
+/// x86-64), but its serial dependency chain loses to LLVM's auto-vectorization
+/// of the counting loop at high limb counts (measured cliff at 24 limbs on
+/// Zen 2, crossover by 64 limbs on Apple M-series).
+const EQ_DW_MAX_LIMBS: usize = 16;
+
 impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// Returns `true` if the value is zero.
     #[inline]
     #[must_use]
     pub fn is_zero(&self) -> bool {
-        *self == Self::ZERO
+        if LIMBS <= EQ_DW_MAX_LIMBS {
+            self.const_is_zero()
+        } else {
+            // Comparing against the constant `ZERO` lowers to `bcmp` against
+            // an all-zeros constant, which beats every const-compatible
+            // formulation at high limb counts but is not reachable from
+            // `const fn`.
+            *self == Self::ZERO
+        }
     }
 
     /// Returns `true` if the value is zero.
     ///
-    /// Note that this currently might perform worse than
-    /// [`is_zero`](Self::is_zero).
+    /// This is equivalent to [`is_zero`](Self::is_zero), usable in `const`
+    /// contexts. For more than 16 limbs (1024 bits) this may perform worse
+    /// than [`is_zero`](Self::is_zero), which can compare against the zero
+    /// constant with `memcmp`.
     #[inline]
     #[must_use]
     pub const fn const_is_zero(&self) -> bool {
-        as_primitives!(self; {
-            u64(x) => return x == 0,
-            u128(x) => return x == 0,
-        });
-        self.const_eq(&Self::ZERO)
+        if LIMBS <= EQ_DW_MAX_LIMBS {
+            self.const_eq(&Self::ZERO)
+        } else {
+            // An OR-fold auto-vectorizes into a plain vector reduction with
+            // no comparisons, which wins at high limb counts. Below the
+            // cutoff the same auto-vectorization costs a vector->scalar
+            // domain crossing that `const_eq`'s chunked form avoids.
+            let mut acc = 0u64;
+            const_range_for!(limb in ref self.as_limbs() => {
+                acc |= *limb;
+            });
+            acc == 0
+        }
     }
 
     /// Returns `true` if `self` equals `other`.
     ///
-    /// Note that this currently might perform worse than the derived
-    /// `PartialEq` (`==` operator).
+    /// This is equivalent to the derived `PartialEq` (`==` operator), usable
+    /// in `const` contexts.
     #[inline]
     #[must_use]
     pub const fn const_eq(&self, other: &Self) -> bool {
-        as_primitives!(self, other; {
-            u64(x, y) => return x == y,
-            u128(x, y) => return x == y,
-        });
         // TODO: Replace with `self == other` and deprecate once `PartialEq` is const.
-        let a = self.as_limbs();
-        let b = other.as_limbs();
-        let mut equal_count = 0usize;
-        const_range_for!(i in 0..LIMBS => {
-            equal_count += (a[i] == b[i]) as usize;
-        });
-        equal_count == LIMBS
-    }
-
-    /// Returns `true` if `self` equals `other`.
-    ///
-    /// Prototype reformulation of [`const_eq`](Self::const_eq) that compares
-    /// double-word (`u128`) chunks instead of counting equal limbs. LLVM
-    /// lowers this to the same code as the derived `PartialEq` (`==`), while
-    /// the limb-counting loop gets auto-vectorized into a horizontal
-    /// reduction with worse dependent-use latency.
-    #[inline]
-    #[must_use]
-    pub const fn const_eq_dw(&self, other: &Self) -> bool {
         as_primitives!(self, other; {
             u64(x, y) => return x == y,
             u128(x, y) => return x == y,
         });
-        let mut eq = true;
-        if LIMBS >= 2 {
-            let a = self.as_double_words();
-            let b = other.as_double_words();
-            const_range_for!(i in 0..LIMBS / 2 => {
-                eq &= a[i].get() == b[i].get();
+        if LIMBS <= EQ_DW_MAX_LIMBS {
+            let mut eq = true;
+            if LIMBS >= 2 {
+                let a = self.as_double_words();
+                let b = other.as_double_words();
+                const_range_for!(i in 0..LIMBS / 2 => {
+                    eq &= a[i].get() == b[i].get();
+                });
+            }
+            if LIMBS % 2 == 1 {
+                eq &= self.limbs[LIMBS - 1] == other.limbs[LIMBS - 1];
+            }
+            eq
+        } else {
+            let a = self.as_limbs();
+            let b = other.as_limbs();
+            let mut equal_count = 0usize;
+            const_range_for!(i in 0..LIMBS => {
+                equal_count += (a[i] == b[i]) as usize;
             });
+            equal_count == LIMBS
         }
-        if LIMBS % 2 == 1 {
-            eq &= self.limbs[LIMBS - 1] == other.limbs[LIMBS - 1];
-        }
-        eq
-    }
-
-    /// Returns `true` if the value is zero.
-    ///
-    /// Prototype reformulation of [`const_is_zero`](Self::const_is_zero) on
-    /// top of [`const_eq_dw`](Self::const_eq_dw).
-    #[inline]
-    #[must_use]
-    pub const fn const_is_zero_dw(&self) -> bool {
-        as_primitives!(self; {
-            u64(x) => return x == 0,
-            u128(x) => return x == 0,
-        });
-        self.const_eq_dw(&Self::ZERO)
     }
 }
 
@@ -239,35 +238,35 @@ mod tests {
     }
 
     #[test]
-    fn test_const_eq_dw_ctfe() {
+    fn test_const_eq_ctfe() {
         const OK: bool = {
             let a = Uint::<256, 4>::from_limbs([1, 2, 3, 4]);
             let b = Uint::<256, 4>::from_limbs([1, 2, 3, 5]);
             let c = Uint::<192, 3>::from_limbs([1, 2, 3]);
             let d = Uint::<192, 3>::from_limbs([1, 2, 4]);
-            a.const_eq_dw(&a)
-                && !a.const_eq_dw(&b)
-                && !a.const_is_zero_dw()
-                && Uint::<256, 4>::ZERO.const_is_zero_dw()
-                && c.const_eq_dw(&c)
-                && !c.const_eq_dw(&d)
+            a.const_eq(&a)
+                && !a.const_eq(&b)
+                && !a.const_is_zero()
+                && Uint::<256, 4>::ZERO.const_is_zero()
+                && c.const_eq(&c)
+                && !c.const_eq(&d)
         };
         const { assert!(OK) };
     }
 
     #[test]
-    fn test_const_eq_dw() {
+    fn test_const_eq() {
         const_for!(BITS in SIZES {
             const LIMBS: usize = nlimbs(BITS);
             type U = Uint<BITS, LIMBS>;
-            assert!(U::ZERO.const_eq_dw(&U::ZERO));
-            assert!(U::ZERO.const_is_zero_dw());
-            assert!(U::MAX.const_eq_dw(&U::MAX));
-            assert_eq!(U::MAX.const_is_zero_dw(), U::MAX.is_zero());
+            assert!(U::ZERO.const_eq(&U::ZERO));
+            assert!(U::ZERO.const_is_zero());
+            assert!(U::MAX.const_eq(&U::MAX));
+            assert_eq!(U::MAX.const_is_zero(), U::MAX.is_zero());
             proptest!(|(a: U, b: U)| {
-                prop_assert_eq!(a.const_eq_dw(&b), a == b);
-                prop_assert!(a.const_eq_dw(&a));
-                prop_assert_eq!(a.const_is_zero_dw(), a.is_zero());
+                prop_assert_eq!(a.const_eq(&b), a == b);
+                prop_assert!(a.const_eq(&a));
+                prop_assert_eq!(a.const_is_zero(), a.is_zero());
             });
         });
         // A difference in any single limb must be detected.
@@ -278,8 +277,8 @@ mod tests {
                 let mut b = a;
                 // Bit 0 of every limb is always within the mask.
                 unsafe { b.as_limbs_mut()[limb] ^= 1 };
-                prop_assert!(!a.const_eq_dw(&b));
-                prop_assert!(!b.const_eq_dw(&a));
+                prop_assert!(!a.const_eq(&b));
+                prop_assert!(!b.const_eq(&a));
             });
         });
     }

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -95,20 +95,26 @@ impl_for_primitives!(
     i8, i16, i32, i64, i128, isize,
 );
 
-/// `const_eq` compares double-word chunks up to this many limbs, and falls
-/// back to a limb-counting loop above it. The chunked form lowers to the same
-/// code as the derived `PartialEq` (flag chain on aarch64, `pxor`/`ptest` on
-/// x86-64), but its serial dependency chain loses to LLVM's auto-vectorization
-/// of the counting loop at high limb counts (measured cliff at 24 limbs on
-/// Zen 2, crossover by 64 limbs on Apple M-series).
-const EQ_DW_MAX_LIMBS: usize = 16;
+/// `const_eq` XOR-folds the limbs up to this many limbs, and falls back to a
+/// limb-counting loop above it. LLVM lowers the fold by context: when the
+/// result feeds a dependency chain and the operands live in registers it
+/// stays scalar (`xor`/`or` on x86-64, `ccmp` flags on aarch64), avoiding
+/// the vector round-trip that stalls dependent use (measured 44% faster
+/// per link than the double-word form on Zen 2 at 256 bits); standalone it
+/// re-vectorizes at 8+ limbs (`pxor`/`ptest` on x86-64, NEON on aarch64).
+/// At 4 limbs x86-64 keeps even the standalone form scalar, costing ~0.3 ns
+/// against `ptest` but still beating the derived `PartialEq`. At high limb
+/// counts the serial forms lose to LLVM's auto-vectorization of the counting
+/// loop (measured cliff at 24 limbs on Zen 2, crossover by 64 limbs on Apple
+/// M-series).
+const EQ_FOLD_MAX_LIMBS: usize = 16;
 
 impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// Returns `true` if the value is zero.
     #[inline]
     #[must_use]
     pub fn is_zero(&self) -> bool {
-        if LIMBS <= EQ_DW_MAX_LIMBS {
+        if LIMBS <= EQ_FOLD_MAX_LIMBS {
             self.const_is_zero()
         } else {
             // Comparing against the constant `ZERO` lowers to `bcmp` against
@@ -128,7 +134,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     #[inline]
     #[must_use]
     pub const fn const_is_zero(&self) -> bool {
-        if LIMBS <= EQ_DW_MAX_LIMBS {
+        if LIMBS <= EQ_FOLD_MAX_LIMBS {
             self.const_eq(&Self::ZERO)
         } else {
             // An OR-fold auto-vectorizes into a plain vector reduction with
@@ -155,19 +161,14 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
             u64(x, y) => return x == y,
             u128(x, y) => return x == y,
         });
-        if LIMBS <= EQ_DW_MAX_LIMBS {
-            let mut eq = true;
-            if LIMBS >= 2 {
-                let a = self.as_double_words();
-                let b = other.as_double_words();
-                const_range_for!(i in 0..LIMBS / 2 => {
-                    eq &= a[i].get() == b[i].get();
-                });
-            }
-            if LIMBS % 2 == 1 {
-                eq &= self.limbs[LIMBS - 1] == other.limbs[LIMBS - 1];
-            }
-            eq
+        if LIMBS <= EQ_FOLD_MAX_LIMBS {
+            let a = self.as_limbs();
+            let b = other.as_limbs();
+            let mut acc = 0;
+            const_range_for!(i in 0..LIMBS => {
+                acc |= a[i] ^ b[i];
+            });
+            acc == 0
         } else {
             let a = self.as_limbs();
             let b = other.as_limbs();


### PR DESCRIPTION
## Motivation

`const_eq` and `const_is_zero` were documented as "might perform worse" than the derived `PartialEq` / `is_zero`. The cause: their hand-rolled limb loops get auto-vectorized by LLVM into a SIMD horizontal reduction (`cmeq`+`umaxv`+`fmov` on aarch64, a scalar `sete`/`adcl` counting chain for `const_is_zero` on x86-64), which costs up to **3.5x dependent-use latency** vs the slice-equality lowering the derived impls get. This was a known tradeoff from #441.

Investigating the fix on x86-64 surfaced a second, worse pathology (previously #617, now folded into this PR): any vector-compare lowering of equality stalls in dependency chains. The consumer updates limbs with scalar code (4×8-byte stores from an `adc` chain), and the next compare reloads them as 16-byte vector loads; a 16-byte load spanning two 8-byte stores **fails store-to-load forwarding** and stalls until the stores drain. On Zen 2 that puts the derived `==` at 8.45 ns/link chained vs 1.30 ns standalone.

## Solution

Reformulate so the const fns lower to scalar-friendly machine code in dependent use while keeping everything `const`-evaluable:

- **`const_eq`**: a limb-wise XOR/OR fold (`acc |= a[i] ^ b[i]`) for `LIMBS <= 16` (`EQ_FOLD_MAX_LIMBS`). LLVM lowers the fold by context: when the result feeds a dependency chain it stays scalar (pure-GPR `xor`/`or` on x86-64 — no memory round-trip, so no STLF stall; a `ccmp` flag chain on aarch64, identical to what the derived `==` gets), while standalone it re-vectorizes at 8+ limbs (`pxor`/`ptest` on x86-64, NEON on aarch64). No `cfg(target_arch)` needed. Above 16 limbs the old counting loop is kept — the serial chain hits a measured cliff at 24 limbs on Zen 2, while the counting loop auto-vectorizes well at high limb counts.
- **`const_is_zero`**: `const_eq(&ZERO)` for `LIMBS <= 16`; a plain OR-fold above (vectorizes to a compare-free reduction). Note a naive OR-fold at *small* widths is a trap: it auto-vectorizes back into the reduction+domain-crossing pathology.
- **`is_zero`**: delegates to `const_is_zero` for `LIMBS <= 16`; keeps `*self == Self::ZERO` above, where LLVM's `bcmp` against the zeros constant beats every const-compatible form (1.6 ns vs ~10 ns at 4096 bits) and is unreachable from `const fn`.

`PartialEq` remains derived so `Uint` keeps `StructuralPartialEq` (const pattern matching). The "might perform worse" caveats are removed, except a scoped note on `const_is_zero` above `EQ_FOLD_MAX_LIMBS`.

Also adds `const_eq` / `const_is_zero` criterion benches.

## Measurements

Two machines: Apple M-series (aarch64) and AMD Threadripper 3990X (Zen 2, x86-64).

U256 dependent-chain latency (result feeds next input, per link):

| | before | after | derived baseline |
|---|---|---|---|
| `const_eq` (M-series) | 5.95 ns | **1.68 ns** | `==` 1.65 ns |
| `const_is_zero` (M-series) | 5.95 ns | **1.25 ns** | `is_zero` 1.30 ns |
| `const_is_zero` (Zen 2) | 3.62 ns | **2.89 ns** | `is_zero` 2.89 ns |
| `const_eq` (Zen 2) | 3.71 ns (dw form) | **2.09 ns (−44%)** | `==` 8.45 ns |

At 512 bits the fold is −52% per link on Zen 2 (~6.5 → 3.40 ns) and −11% on M-series. Distribution guards (`dist/eq/*`, `dist/is_zero/*`) and the untouched derived `==` are flat on both machines.

Throughput (independent random inputs) is neutral-to-better at nearly every width; highlights: `const_eq/192` 613→478 ps, `const_is_zero/256` 575→384 ps (now beats old `is_zero`'s 421 ps), `is_zero/384`/`512` improve 18–23% on Zen 2 (memcmp call → inline `ptest`). Known tradeoffs: `const_eq` +5-8% at 384/512 bits on M-series random inputs, and standalone `const_eq/256` on Zen 2 goes 0.85 → 1.12 ns (+34%) — at exactly 4 limbs x86-64 keeps even the standalone fold scalar. 1.12 ns still beats the derived `==` (1.32 ns) on the same inputs, and an equality result in real code is almost always consumed dependently — which is where the 44% win is — so this is the right trade. Documented in the `EQ_FOLD_MAX_LIMBS` comment.

## Wall-clock benchmarks are the only regression guard

The headline wins here are **latency-shaped**: they come from avoiding dependency stalls (STLF failures, vector→scalar domain crossings), not from executing fewer instructions. Instruction-count instrumentation (CodSpeed) is blind to both the pathology and the fix — expect it to show only the `is_zero/384`,`/512` improvements plus new benchmark entries. The same blindness applies in reverse: a future LLVM upgrade could silently re-vectorize the chained case, and only the wall-clock `chained/const_eq/*` latency benches (in the real-world benchmark suite, see #616) would catch it. This is noted in the code comment on `EQ_FOLD_MAX_LIMBS`.

## PR Checklist

- [x] Added Tests (CTFE evaluation including the >16-limb fallback branches, proptest equivalence with `==`/`is_zero` at all SIZES plus the 16/17-limb cutoff boundary, single-bit-flip detection at every limb position)
- [x] Added Documentation
- [x] Breaking changes: none (`PartialEq` derive untouched, structural match preserved)

Supersedes and absorbs #617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJ4S2Ns5cyvmkTFJ7mgrWE
