### PR TITLE
perf: rewrite square_redc to unroll and use single-word carries

### DIFF
--- a/benches/benches/curves.rs
+++ b/benches/benches/curves.rs
@@ -5,7 +5,7 @@
 //! pressure, op mix, and memory patterns of real signature/pairing code,
 //! which single-op benches cannot.
 
-use super::fields::{check_field, Fq, BLS12_381_P, SECP256K1_N, SECP256K1_P, U256, U384};
+use super::fields::{BLS12_381_P, Fq, SECP256K1_N, SECP256K1_P, U256, U384, check_field};
 use crate::prelude::*;
 
 const G_X: U256 = uint!(0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798_U256);
@@ -48,7 +48,11 @@ fn jac_double<const BITS: usize, const LIMBS: usize>(
         let t = f.mul(p.y, p.z);
         f.add(t, t)
     };
-    Jac { x: x3, y: y3, z: z3 }
+    Jac {
+        x: x3,
+        y: y3,
+        z: z3,
+    }
 }
 
 /// General addition (EFD add-2007-bl). Requires P ≠ ±Q and both nonzero.
@@ -80,7 +84,11 @@ fn jac_add<const BITS: usize, const LIMBS: usize>(
         f.sub(f.mul(r, f.sub(v, x3)), f.add(t, t))
     };
     let z3 = f.mul(f.sub(f.sub(f.sqr(f.add(p.z, q.z)), z1z1), z2z2), h);
-    Jac { x: x3, y: y3, z: z3 }
+    Jac {
+        x: x3,
+        y: y3,
+        z: z3,
+    }
 }
 
 /// Fp2 = Fp[u]/(u² + 1) multiplication, Karatsuba: 3 muls + 5 add/subs.
@@ -147,7 +155,11 @@ fn to_affine<const BITS: usize, const LIMBS: usize>(
 /// Known-answer checks: a wrong formula or constant panics here.
 fn sanity_checks() {
     let f = check_field("secp256k1_p", SECP256K1_P);
-    let g = Jac { x: f.to_mont(G_X), y: f.to_mont(G_Y), z: f.r1 };
+    let g = Jac {
+        x: f.to_mont(G_X),
+        y: f.to_mont(G_Y),
+        z: f.r1,
+    };
     let g2 = jac_double(&f, g);
     assert_eq!(to_affine(&f, g2), (G2_X, G2_Y), "jac_double: 2G mismatch");
     let g3 = jac_add(&f, g2, g);
@@ -159,13 +171,24 @@ fn sanity_checks() {
         d16 = jac_double(&f, d16);
     }
     let seg = scalar_mul_segment(&f, g, g, 0);
-    assert_eq!(to_affine(&f, seg), to_affine(&f, d16), "scalar_mul_segment: k=0");
+    assert_eq!(
+        to_affine(&f, seg),
+        to_affine(&f, d16),
+        "scalar_mul_segment: k=0"
+    );
 
     // Fp2: (a0 + a1·u)(a0 − a1·u) = a0² + a1², and u·u = −1.
     let f2 = check_field("bls12_381_p", BLS12_381_P);
-    let (a0, a1) = (f2.to_mont(Uint::from(1234u64)), f2.to_mont(Uint::from(5678u64)));
+    let (a0, a1) = (
+        f2.to_mont(Uint::from(1234u64)),
+        f2.to_mont(Uint::from(5678u64)),
+    );
     let conj = fp2_mul(&f2, (a0, a1), (a0, f2.sub(Uint::ZERO, a1)));
-    assert_eq!(conj, (f2.add(f2.sqr(a0), f2.sqr(a1)), Uint::ZERO), "fp2_mul: conjugate");
+    assert_eq!(
+        conj,
+        (f2.add(f2.sqr(a0), f2.sqr(a1)), Uint::ZERO),
+        "fp2_mul: conjugate"
+    );
     let u = (Uint::ZERO, f2.r1);
     assert_eq!(
         fp2_mul(&f2, u, u),
@@ -190,7 +213,11 @@ fn jac_point_strategy<const BITS: usize, const LIMBS: usize>(
     p: Uint<BITS, LIMBS>,
 ) -> impl Strategy<Value = Jac<BITS, LIMBS>> {
     <(Uint<BITS, LIMBS>, Uint<BITS, LIMBS>, Uint<BITS, LIMBS>)>::arbitrary().prop_map(
-        move |(x, y, z)| Jac { x: x.reduce_mod(p), y: y.reduce_mod(p), z: z.reduce_mod(p) },
+        move |(x, y, z)| Jac {
+            x: x.reduce_mod(p),
+            y: y.reduce_mod(p),
+            z: z.reduce_mod(p),
+        },
     )
 }
 
@@ -237,7 +264,11 @@ pub fn group(criterion: &mut Criterion) {
     bench_arbitrary_with(
         criterion,
         "curves/secp256k1/scalar_mul_segment16",
-        (jac_point_strategy(SECP256K1_P), jac_point_strategy(SECP256K1_P), u16::arbitrary()),
+        (
+            jac_point_strategy(SECP256K1_P),
+            jac_point_strategy(SECP256K1_P),
+            u16::arbitrary(),
+        ),
         move |(acc, q, k)| scalar_mul_segment(&f, acc, q, k),
     );
 
@@ -246,11 +277,7 @@ pub fn group(criterion: &mut Criterion) {
     let scalar = move || {
         U256::arbitrary().prop_map(move |x| {
             let x = x.reduce_mod(n);
-            if x.is_zero() {
-                U256::ONE
-            } else {
-                x
-            }
+            if x.is_zero() { U256::ONE } else { x }
         })
     };
     bench_arbitrary_with(
@@ -267,11 +294,7 @@ pub fn group(criterion: &mut Criterion) {
     let nonzero = move || {
         U256::arbitrary().prop_map(move |x| {
             let x = x.reduce_mod(SECP256K1_P);
-            if x.is_zero() {
-                U256::ONE
-            } else {
-                x
-            }
+            if x.is_zero() { U256::ONE } else { x }
         })
     };
     bench_arbitrary_with(

--- a/benches/benches/curves.rs
+++ b/benches/benches/curves.rs
@@ -1,0 +1,139 @@
+//! Composite elliptic-curve kernels built from ruint field primitives:
+//! Jacobian point double/add (secp256k1 and BLS12-381 G1, both a = 0),
+//! Fp2 multiplication, a 16-bit double-and-add scalar segment, the ECDSA
+//! verify scalar prologue, and batch inversion. These exercise the register
+//! pressure, op mix, and memory patterns of real signature/pairing code,
+//! which single-op benches cannot.
+
+use super::fields::{check_field, Fq, BLS12_381_P, SECP256K1_P, U256};
+use crate::prelude::*;
+
+const G_X: U256 = uint!(0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798_U256);
+const G_Y: U256 = uint!(0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8_U256);
+const G2_X: U256 = uint!(0xc6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5_U256);
+const G2_Y: U256 = uint!(0x1ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a_U256);
+const G3_X: U256 = uint!(0xf9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9_U256);
+const G3_Y: U256 = uint!(0x388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e672_U256);
+
+/// Jacobian point (x/z², y/z³), coordinates in Montgomery form.
+#[derive(Clone, Copy, Debug)]
+struct Jac<const BITS: usize, const LIMBS: usize> {
+    x: Uint<BITS, LIMBS>,
+    y: Uint<BITS, LIMBS>,
+    z: Uint<BITS, LIMBS>,
+}
+
+/// Doubling for a = 0 curves (EFD dbl-2009-l).
+fn jac_double<const BITS: usize, const LIMBS: usize>(
+    f: &Fq<BITS, LIMBS>,
+    p: Jac<BITS, LIMBS>,
+) -> Jac<BITS, LIMBS> {
+    let a = f.sqr(p.x);
+    let b = f.sqr(p.y);
+    let c = f.sqr(b);
+    let d = {
+        let t = f.sub(f.sub(f.sqr(f.add(p.x, b)), a), c);
+        f.add(t, t)
+    };
+    let e = f.add(f.add(a, a), a);
+    let ff = f.sqr(e);
+    let x3 = f.sub(ff, f.add(d, d));
+    let c8 = {
+        let c2 = f.add(c, c);
+        let c4 = f.add(c2, c2);
+        f.add(c4, c4)
+    };
+    let y3 = f.sub(f.mul(e, f.sub(d, x3)), c8);
+    let z3 = {
+        let t = f.mul(p.y, p.z);
+        f.add(t, t)
+    };
+    Jac { x: x3, y: y3, z: z3 }
+}
+
+/// General addition (EFD add-2007-bl). Requires P ≠ ±Q and both nonzero.
+fn jac_add<const BITS: usize, const LIMBS: usize>(
+    f: &Fq<BITS, LIMBS>,
+    p: Jac<BITS, LIMBS>,
+    q: Jac<BITS, LIMBS>,
+) -> Jac<BITS, LIMBS> {
+    let z1z1 = f.sqr(p.z);
+    let z2z2 = f.sqr(q.z);
+    let u1 = f.mul(p.x, z2z2);
+    let u2 = f.mul(q.x, z1z1);
+    let s1 = f.mul(f.mul(p.y, q.z), z2z2);
+    let s2 = f.mul(f.mul(q.y, p.z), z1z1);
+    let h = f.sub(u2, u1);
+    let i = {
+        let h2 = f.add(h, h);
+        f.sqr(h2)
+    };
+    let j = f.mul(h, i);
+    let r = {
+        let t = f.sub(s2, s1);
+        f.add(t, t)
+    };
+    let v = f.mul(u1, i);
+    let x3 = f.sub(f.sub(f.sqr(r), j), f.add(v, v));
+    let y3 = {
+        let t = f.mul(s1, j);
+        f.sub(f.mul(r, f.sub(v, x3)), f.add(t, t))
+    };
+    let z3 = f.mul(f.sub(f.sub(f.sqr(f.add(p.z, q.z)), z1z1), z2z2), h);
+    Jac { x: x3, y: y3, z: z3 }
+}
+
+/// Montgomery-form Jacobian point back to plain affine coordinates.
+fn to_affine<const BITS: usize, const LIMBS: usize>(
+    f: &Fq<BITS, LIMBS>,
+    p: Jac<BITS, LIMBS>,
+) -> (Uint<BITS, LIMBS>, Uint<BITS, LIMBS>) {
+    let (x, y, z) = (f.from_mont(p.x), f.from_mont(p.y), f.from_mont(p.z));
+    let zi = z.inv_mod(f.p).unwrap();
+    let zi2 = zi.mul_mod(zi, f.p);
+    (x.mul_mod(zi2, f.p), y.mul_mod(zi2.mul_mod(zi, f.p), f.p))
+}
+
+/// Known-answer checks: a wrong formula or constant panics here.
+fn sanity_checks() {
+    let f = check_field("secp256k1_p", SECP256K1_P);
+    let g = Jac { x: f.to_mont(G_X), y: f.to_mont(G_Y), z: f.r1 };
+    let g2 = jac_double(&f, g);
+    assert_eq!(to_affine(&f, g2), (G2_X, G2_Y), "jac_double: 2G mismatch");
+    let g3 = jac_add(&f, g2, g);
+    assert_eq!(to_affine(&f, g3), (G3_X, G3_Y), "jac_add: 3G mismatch");
+}
+
+fn jac_point_strategy<const BITS: usize, const LIMBS: usize>(
+    p: Uint<BITS, LIMBS>,
+) -> impl Strategy<Value = Jac<BITS, LIMBS>> {
+    <(Uint<BITS, LIMBS>, Uint<BITS, LIMBS>, Uint<BITS, LIMBS>)>::arbitrary().prop_map(
+        move |(x, y, z)| Jac { x: x.reduce_mod(p), y: y.reduce_mod(p), z: z.reduce_mod(p) },
+    )
+}
+
+fn bench_curve<const BITS: usize, const LIMBS: usize>(
+    criterion: &mut Criterion,
+    name: &str,
+    p: Uint<BITS, LIMBS>,
+) {
+    let f = Fq::new(p);
+    bench_arbitrary_with(
+        criterion,
+        &format!("curves/{name}/jac_double"),
+        jac_point_strategy(p),
+        move |pt| jac_double(&f, pt),
+    );
+    bench_arbitrary_with(
+        criterion,
+        &format!("curves/{name}/jac_add"),
+        (jac_point_strategy(p), jac_point_strategy(p)),
+        move |(a, b)| jac_add(&f, a, b),
+    );
+}
+
+pub fn group(criterion: &mut Criterion) {
+    sanity_checks();
+    bench_curve(criterion, "secp256k1", SECP256K1_P);
+    bench_curve(criterion, "bls12_381_g1", BLS12_381_P);
+}

--- a/benches/benches/curves.rs
+++ b/benches/benches/curves.rs
@@ -5,7 +5,7 @@
 //! pressure, op mix, and memory patterns of real signature/pairing code,
 //! which single-op benches cannot.
 
-use super::fields::{check_field, Fq, BLS12_381_P, SECP256K1_P, U256};
+use super::fields::{check_field, Fq, BLS12_381_P, SECP256K1_N, SECP256K1_P, U256, U384};
 use crate::prelude::*;
 
 const G_X: U256 = uint!(0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798_U256);
@@ -83,6 +83,56 @@ fn jac_add<const BITS: usize, const LIMBS: usize>(
     Jac { x: x3, y: y3, z: z3 }
 }
 
+/// Fp2 = Fp[u]/(u² + 1) multiplication, Karatsuba: 3 muls + 5 add/subs.
+fn fp2_mul<const BITS: usize, const LIMBS: usize>(
+    f: &Fq<BITS, LIMBS>,
+    a: (Uint<BITS, LIMBS>, Uint<BITS, LIMBS>),
+    b: (Uint<BITS, LIMBS>, Uint<BITS, LIMBS>),
+) -> (Uint<BITS, LIMBS>, Uint<BITS, LIMBS>) {
+    let t0 = f.mul(a.0, b.0);
+    let t1 = f.mul(a.1, b.1);
+    let t2 = f.mul(f.add(a.0, a.1), f.add(b.0, b.1));
+    (f.sub(t0, t1), f.sub(f.sub(t2, t0), t1))
+}
+
+/// 16 double-and-add iterations: the repeating unit of scalar multiplication,
+/// with the real data-dependent branch on scalar bits.
+fn scalar_mul_segment<const BITS: usize, const LIMBS: usize>(
+    f: &Fq<BITS, LIMBS>,
+    mut acc: Jac<BITS, LIMBS>,
+    q: Jac<BITS, LIMBS>,
+    k: u16,
+) -> Jac<BITS, LIMBS> {
+    for i in (0..16).rev() {
+        acc = jac_double(f, acc);
+        if (k >> i) & 1 == 1 {
+            acc = jac_add(f, acc, q);
+        }
+    }
+    acc
+}
+
+/// Batch inversion via Montgomery's trick: N−1 prefix muls, one inv, 2(N−1)
+/// muls back. All values in Montgomery form.
+fn batch_inverse<const BITS: usize, const LIMBS: usize, const N: usize>(
+    f: &Fq<BITS, LIMBS>,
+    xs: [Uint<BITS, LIMBS>; N],
+) -> [Uint<BITS, LIMBS>; N] {
+    let mut prefix = [Uint::ZERO; N];
+    let mut acc = f.r1;
+    for i in 0..N {
+        prefix[i] = acc;
+        acc = f.mul(acc, xs[i]);
+    }
+    let mut inv_acc = f.inv(acc);
+    let mut out = [Uint::ZERO; N];
+    for i in (0..N).rev() {
+        out[i] = f.mul(inv_acc, prefix[i]);
+        inv_acc = f.mul(inv_acc, xs[i]);
+    }
+    out
+}
+
 /// Montgomery-form Jacobian point back to plain affine coordinates.
 fn to_affine<const BITS: usize, const LIMBS: usize>(
     f: &Fq<BITS, LIMBS>,
@@ -102,6 +152,38 @@ fn sanity_checks() {
     assert_eq!(to_affine(&f, g2), (G2_X, G2_Y), "jac_double: 2G mismatch");
     let g3 = jac_add(&f, g2, g);
     assert_eq!(to_affine(&f, g3), (G3_X, G3_Y), "jac_add: 3G mismatch");
+
+    // Scalar segment with k = 0 must equal 16 straight doublings.
+    let mut d16 = g;
+    for _ in 0..16 {
+        d16 = jac_double(&f, d16);
+    }
+    let seg = scalar_mul_segment(&f, g, g, 0);
+    assert_eq!(to_affine(&f, seg), to_affine(&f, d16), "scalar_mul_segment: k=0");
+
+    // Fp2: (a0 + a1·u)(a0 − a1·u) = a0² + a1², and u·u = −1.
+    let f2 = check_field("bls12_381_p", BLS12_381_P);
+    let (a0, a1) = (f2.to_mont(Uint::from(1234u64)), f2.to_mont(Uint::from(5678u64)));
+    let conj = fp2_mul(&f2, (a0, a1), (a0, f2.sub(Uint::ZERO, a1)));
+    assert_eq!(conj, (f2.add(f2.sqr(a0), f2.sqr(a1)), Uint::ZERO), "fp2_mul: conjugate");
+    let u = (Uint::ZERO, f2.r1);
+    assert_eq!(
+        fp2_mul(&f2, u, u),
+        (f2.to_mont(f2.p.wrapping_sub(Uint::ONE)), Uint::ZERO),
+        "fp2_mul: u^2 != -1"
+    );
+
+    // Batch inversion: xᵢ · out[i] == 1 (Montgomery form) for all i.
+    let xs = [
+        f2.to_mont(Uint::from(2u64)),
+        f2.to_mont(Uint::from(3u64)),
+        f2.to_mont(Uint::from(65537u64)),
+        a1,
+    ];
+    let inv = batch_inverse(&f2, xs);
+    for i in 0..xs.len() {
+        assert_eq!(f2.mul(xs[i], inv[i]), f2.r1, "batch_inverse[{i}]");
+    }
 }
 
 fn jac_point_strategy<const BITS: usize, const LIMBS: usize>(
@@ -136,4 +218,70 @@ pub fn group(criterion: &mut Criterion) {
     sanity_checks();
     bench_curve(criterion, "secp256k1", SECP256K1_P);
     bench_curve(criterion, "bls12_381_g1", BLS12_381_P);
+
+    // Fp2 multiplication (BLS12-381).
+    let f381 = Fq::new(BLS12_381_P);
+    let fp2_el = move || {
+        <(U384, U384)>::arbitrary()
+            .prop_map(move |(a, b)| (a.reduce_mod(BLS12_381_P), b.reduce_mod(BLS12_381_P)))
+    };
+    bench_arbitrary_with(
+        criterion,
+        "curves/bls12_381/fp2_mul",
+        (fp2_el(), fp2_el()),
+        move |(a, b)| fp2_mul(&f381, a, b),
+    );
+
+    // Scalar-mul segment (secp256k1): 16 doubles + data-dependent adds.
+    let f = Fq::new(SECP256K1_P);
+    bench_arbitrary_with(
+        criterion,
+        "curves/secp256k1/scalar_mul_segment16",
+        (jac_point_strategy(SECP256K1_P), jac_point_strategy(SECP256K1_P), u16::arbitrary()),
+        move |(acc, q, k)| scalar_mul_segment(&f, acc, q, k),
+    );
+
+    // ECDSA verify scalar prologue: w = s⁻¹ mod n; u1 = z·w; u2 = r·w.
+    let n = SECP256K1_N;
+    let scalar = move || {
+        U256::arbitrary().prop_map(move |x| {
+            let x = x.reduce_mod(n);
+            if x.is_zero() {
+                U256::ONE
+            } else {
+                x
+            }
+        })
+    };
+    bench_arbitrary_with(
+        criterion,
+        "curves/secp256k1/ecdsa_verify_prologue",
+        (scalar(), scalar(), scalar()),
+        move |(z, r, s)| {
+            let w = s.inv_mod(n).unwrap();
+            (z.mul_mod(w, n), r.mul_mod(w, n))
+        },
+    );
+
+    // Batch inversion of 64 elements (Montgomery's trick).
+    let nonzero = move || {
+        U256::arbitrary().prop_map(move |x| {
+            let x = x.reduce_mod(SECP256K1_P);
+            if x.is_zero() {
+                U256::ONE
+            } else {
+                x
+            }
+        })
+    };
+    bench_arbitrary_with(
+        criterion,
+        "curves/secp256k1/batch_inverse64",
+        proptest::collection::vec(nonzero(), 64).prop_map(|v| {
+            let mut arr = [U256::ZERO; 64];
+            arr.copy_from_slice(&v);
+            arr
+        }),
+        move |xs| batch_inverse(&f, xs),
+    );
 }

--- a/benches/benches/distributions.rs
+++ b/benches/benches/distributions.rs
@@ -38,6 +38,33 @@ pub fn group(criterion: &mut Criterion) {
         |(a, b)| a == b,
     );
 
+    // const_eq over the same distributions: guards the const-compatible
+    // formulation against distribution-sensitive regressions.
+    bench_arbitrary_with(
+        criterion,
+        "dist/const_eq/equal/256",
+        U256::arbitrary().prop_map(|x| (x, x)),
+        |(a, b)| a.const_eq(&b),
+    );
+    bench_arbitrary_with(
+        criterion,
+        "dist/const_eq/differ_low/256",
+        U256::arbitrary().prop_map(|x| (x, x ^ U256::ONE)),
+        |(a, b)| a.const_eq(&b),
+    );
+    bench_arbitrary_with(
+        criterion,
+        "dist/const_eq/differ_high/256",
+        U256::arbitrary().prop_map(|x| (x, x ^ (U256::ONE << 255))),
+        |(a, b)| a.const_eq(&b),
+    );
+    bench_arbitrary_with(
+        criterion,
+        "dist/const_eq/mixed50/256",
+        <(U256, bool)>::arbitrary().prop_map(|(x, e)| if e { (x, x) } else { (x, x ^ U256::ONE) }),
+        |(a, b)| a.const_eq(&b),
+    );
+
     // is_zero: mostly-nonzero stream with 10% zeros (flag-checking pattern).
     bench_arbitrary_with(
         criterion,

--- a/benches/benches/distributions.rs
+++ b/benches/benches/distributions.rs
@@ -1,0 +1,89 @@
+//! Comparison benchmarks with *realistic* input distributions. The existing
+//! `cmp` group uses uniform-random inputs, where `eq` is decided in the first
+//! limb ~100% of the time and every branch is perfectly predictable. Real
+//! 256-bit words are skewed: small counters, 160-bit addresses, hashes, and
+//! equality checks that are usually true or differ late. Branchy and
+//! branchless implementations rank differently across these distributions —
+//! wall-clock only; CodSpeed's simulator does not model prediction.
+
+use super::fields::U256;
+use crate::prelude::*;
+use proptest::{prop_oneof, strategy::Just};
+
+pub fn group(criterion: &mut Criterion) {
+    // eq: outcome and differing-limb position.
+    bench_arbitrary_with(
+        criterion,
+        "dist/eq/equal/256",
+        U256::arbitrary().prop_map(|x| (x, x)),
+        |(a, b)| a == b,
+    );
+    bench_arbitrary_with(
+        criterion,
+        "dist/eq/differ_low/256",
+        U256::arbitrary().prop_map(|x| (x, x ^ U256::ONE)),
+        |(a, b)| a == b,
+    );
+    bench_arbitrary_with(
+        criterion,
+        "dist/eq/differ_high/256",
+        U256::arbitrary().prop_map(|x| (x, x ^ (U256::ONE << 255))),
+        |(a, b)| a == b,
+    );
+    // 50/50 equal: hostile to branch prediction, friendly to branchless.
+    bench_arbitrary_with(
+        criterion,
+        "dist/eq/mixed50/256",
+        <(U256, bool)>::arbitrary().prop_map(|(x, e)| if e { (x, x) } else { (x, x ^ U256::ONE) }),
+        |(a, b)| a == b,
+    );
+
+    // is_zero: mostly-nonzero stream with 10% zeros (flag-checking pattern).
+    bench_arbitrary_with(
+        criterion,
+        "dist/is_zero/mixed10/256",
+        prop_oneof![
+            9 => U256::arbitrary().prop_map(|x| x | U256::ONE),
+            1 => Just(U256::ZERO),
+        ],
+        |a| a.is_zero(),
+    );
+
+    // lt: magnitude distributions.
+    let small = || <(u64, u64)>::arbitrary().prop_map(|(a, b)| (U256::from(a), U256::from(b)));
+    bench_arbitrary_with(criterion, "dist/lt/small64/256", small(), |(a, b)| a < b);
+    let addr_mask: U256 = (U256::ONE << 160) - U256::ONE;
+    bench_arbitrary_with(
+        criterion,
+        "dist/lt/address160/256",
+        <(U256, U256)>::arbitrary().prop_map(move |(a, b)| (a & addr_mask, b & addr_mask)),
+        |(a, b)| a < b,
+    );
+    bench_arbitrary_with(
+        criterion,
+        "dist/lt/mixed_magnitude/256",
+        <(u64, U256)>::arbitrary().prop_map(|(a, b)| (U256::from(a), b)),
+        |(a, b)| a < b,
+    );
+
+    // lt feeding divergent arms: comparison result steers real work.
+    bench_arbitrary_with(criterion, "dist/lt_arms/small64/256", small(), |(a, b)| {
+        if a < b {
+            a.wrapping_add(b)
+        } else {
+            a.wrapping_sub(b)
+        }
+    });
+    bench_arbitrary_with(
+        criterion,
+        "dist/lt_arms/random/256",
+        <(U256, U256)>::arbitrary(),
+        |(a, b)| {
+            if a < b {
+                a.wrapping_add(b)
+            } else {
+                a.wrapping_sub(b)
+            }
+        },
+    );
+}

--- a/benches/benches/fields.rs
+++ b/benches/benches/fields.rs
@@ -1,0 +1,139 @@
+//! Field-arithmetic kernels over the fixed moduli that dominate real-world
+//! ruint usage: secp256k1 (k256 ECDSA, both the base field and the scalar
+//! order), NIST P-256, BN254, BLS12-381, BLS12-377, and CSIDH-512 as the
+//! post-quantum representative.
+//!
+//! Unlike the generic `modular` group (random moduli), these benches use the
+//! actual primes, real fixed exponents (Fermat inversion, sqrt for point
+//! decompression, 65537), and Montgomery-domain kernels (`mul_redc`,
+//! `square_redc`) — the true inner loops of signature and pairing libraries.
+
+use crate::prelude::*;
+use ruint::aliases::U64;
+
+pub(crate) type U256 = Uint<256, 4>;
+pub(crate) type U384 = Uint<384, 6>;
+pub(crate) type U512 = Uint<512, 8>;
+
+// Moduli verified against their generating formulas:
+// secp256k1 p = 2^256 − 2^32 − 977; P-256 p = 2^256 − 2^224 + 2^192 + 2^96 − 1;
+// BN254 from t = 4965661367192848881; BLS12-381 from z = −0xd201000000010000;
+// BLS12-377 from z = 0x8508c00000000001;
+// CSIDH-512 p = 4·(∏ first 73 odd primes)·587 − 1.
+pub(crate) const SECP256K1_P: U256 =
+    uint!(0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f_U256);
+pub(crate) const SECP256K1_N: U256 =
+    uint!(0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141_U256);
+pub(crate) const P256_P: U256 =
+    uint!(0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff_U256);
+pub(crate) const P256_N: U256 =
+    uint!(0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551_U256);
+pub(crate) const BN254_P: U256 =
+    uint!(0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47_U256);
+pub(crate) const BN254_R: U256 =
+    uint!(0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001_U256);
+pub(crate) const BLS12_381_P: U384 =
+    uint!(0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab_U384);
+pub(crate) const BLS12_381_R: U256 =
+    uint!(0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001_U256);
+pub(crate) const BLS12_377_P: U384 =
+    uint!(0x1ae3a4617c510eac63b05c06ca1493b1a22d9f300f5138f1ef3622fba094800170b5d44300000008508c00000000001_U384);
+pub(crate) const BLS12_377_R: U256 =
+    uint!(0x12ab655e9a2ca55660b44d1e5c37b00159aa76fed00000010a11800000000001_U256);
+pub(crate) const CSIDH512_P: U512 =
+    uint!(0x65b48e8f740f89bffc8ab0d15e3e4c4ab42d083aedc88c425afbfcc69322c9cda7aac6c567f35507516730cc1f0b4f25c2721bf457aca8351b81b90533c6c87b_U512);
+
+/// Montgomery context for a fixed odd prime modulus.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Fq<const BITS: usize, const LIMBS: usize> {
+    pub p: Uint<BITS, LIMBS>,
+    pub inv: u64,
+    /// R mod p, i.e. the Montgomery form of 1.
+    pub r1: Uint<BITS, LIMBS>,
+    /// R² mod p.
+    pub r2: Uint<BITS, LIMBS>,
+}
+
+impl<const BITS: usize, const LIMBS: usize> Fq<BITS, LIMBS> {
+    pub fn new(p: Uint<BITS, LIMBS>) -> Self {
+        let inv: u64 = U64::wrapping_from(p).inv_ring().unwrap().wrapping_neg().to();
+        // R mod p = (2^BITS − 1 mod p) + 1; never wraps to 0 since p ∤ 2^BITS.
+        let r1 = (Uint::MAX % p).wrapping_add(Uint::ONE);
+        let r2 = r1.mul_mod(r1, p);
+        Self { p, inv, r1, r2 }
+    }
+
+    pub fn mul(&self, a: Uint<BITS, LIMBS>, b: Uint<BITS, LIMBS>) -> Uint<BITS, LIMBS> {
+        a.mul_redc(b, self.p, self.inv)
+    }
+
+    pub fn sqr(&self, a: Uint<BITS, LIMBS>) -> Uint<BITS, LIMBS> {
+        a.square_redc(self.p, self.inv)
+    }
+
+    pub fn add(&self, a: Uint<BITS, LIMBS>, b: Uint<BITS, LIMBS>) -> Uint<BITS, LIMBS> {
+        a.add_mod(b, self.p)
+    }
+
+    pub fn sub(&self, a: Uint<BITS, LIMBS>, b: Uint<BITS, LIMBS>) -> Uint<BITS, LIMBS> {
+        // a − b mod p for a, b < p: the wrap of `wrapping_sub` and the +p cancel.
+        let d = a.wrapping_sub(b);
+        if a < b {
+            d.wrapping_add(self.p)
+        } else {
+            d
+        }
+    }
+
+    pub fn to_mont(&self, a: Uint<BITS, LIMBS>) -> Uint<BITS, LIMBS> {
+        self.mul(a, self.r2)
+    }
+
+    pub fn from_mont(&self, a: Uint<BITS, LIMBS>) -> Uint<BITS, LIMBS> {
+        self.mul(a, Uint::ONE)
+    }
+
+    /// Montgomery-domain inverse: maps xR to x⁻¹R.
+    pub fn inv(&self, a: Uint<BITS, LIMBS>) -> Uint<BITS, LIMBS> {
+        // inv_mod(xR) = x⁻¹R⁻¹; two redc-muls by R² append the two missing Rs.
+        let i = a.inv_mod(self.p).unwrap();
+        self.mul(self.mul(i, self.r2), self.r2)
+    }
+}
+
+/// Build the context and verify it: wrong constants panic here instead of
+/// silently benchmarking garbage.
+pub(crate) fn check_field<const BITS: usize, const LIMBS: usize>(
+    name: &str,
+    p: Uint<BITS, LIMBS>,
+) -> Fq<BITS, LIMBS> {
+    assert!(p.bit(0), "{name}: modulus must be odd");
+    let f = Fq::new(p);
+    assert_eq!(f.inv.wrapping_mul(p.as_limbs()[0]), u64::MAX, "{name}: bad Montgomery inv");
+    let a = p.wrapping_sub(Uint::from(5u64));
+    let b = (p >> 1usize).wrapping_add(Uint::from(7u64));
+    assert_eq!(f.from_mont(f.to_mont(a)), a, "{name}: Montgomery round-trip");
+    assert_eq!(
+        f.mul(f.to_mont(a), f.to_mont(b)),
+        f.to_mont(a.mul_mod(b, p)),
+        "{name}: mul_redc disagrees with mul_mod"
+    );
+    assert_eq!(f.sqr(f.to_mont(a)), f.mul(f.to_mont(a), f.to_mont(a)), "{name}: square_redc");
+    assert_eq!(f.mul(f.inv(f.to_mont(b)), f.to_mont(b)), f.r1, "{name}: Montgomery inverse");
+    f
+}
+
+pub fn group(criterion: &mut Criterion) {
+    let _ = criterion;
+    check_field("secp256k1_p", SECP256K1_P);
+    check_field("secp256k1_n", SECP256K1_N);
+    check_field("p256_p", P256_P);
+    check_field("p256_n", P256_N);
+    check_field("bn254_p", BN254_P);
+    check_field("bn254_r", BN254_R);
+    check_field("bls12_381_p", BLS12_381_P);
+    check_field("bls12_381_r", BLS12_381_R);
+    check_field("bls12_377_p", BLS12_377_P);
+    check_field("bls12_377_r", BLS12_377_R);
+    check_field("csidh512_p", CSIDH512_P);
+}

--- a/benches/benches/fields.rs
+++ b/benches/benches/fields.rs
@@ -46,17 +46,24 @@ pub(crate) const CSIDH512_P: U512 =
 /// Montgomery context for a fixed odd prime modulus.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct Fq<const BITS: usize, const LIMBS: usize> {
-    pub p: Uint<BITS, LIMBS>,
+    pub p:   Uint<BITS, LIMBS>,
     pub inv: u64,
     /// R mod p, i.e. the Montgomery form of 1.
-    pub r1: Uint<BITS, LIMBS>,
+    pub r1:  Uint<BITS, LIMBS>,
     /// R² mod p.
-    pub r2: Uint<BITS, LIMBS>,
+    pub r2:  Uint<BITS, LIMBS>,
 }
 
+// `to_mont`/`from_mont` are domain conversions on the *argument*; the
+// receiver is the field context, so the self-convention lint does not apply.
+#[allow(clippy::wrong_self_convention)]
 impl<const BITS: usize, const LIMBS: usize> Fq<BITS, LIMBS> {
     pub fn new(p: Uint<BITS, LIMBS>) -> Self {
-        let inv: u64 = U64::wrapping_from(p).inv_ring().unwrap().wrapping_neg().to();
+        let inv: u64 = U64::wrapping_from(p)
+            .inv_ring()
+            .unwrap()
+            .wrapping_neg()
+            .to();
         // R mod p = (2^BITS − 1 mod p) + 1; never wraps to 0 since p ∤ 2^BITS.
         let r1 = (Uint::MAX % p).wrapping_add(Uint::ONE);
         let r2 = r1.mul_mod(r1, p);
@@ -78,11 +85,7 @@ impl<const BITS: usize, const LIMBS: usize> Fq<BITS, LIMBS> {
     pub fn sub(&self, a: Uint<BITS, LIMBS>, b: Uint<BITS, LIMBS>) -> Uint<BITS, LIMBS> {
         // a − b mod p for a, b < p: the wrap of `wrapping_sub` and the +p cancel.
         let d = a.wrapping_sub(b);
-        if a < b {
-            d.wrapping_add(self.p)
-        } else {
-            d
-        }
+        if a < b { d.wrapping_add(self.p) } else { d }
     }
 
     pub fn to_mont(&self, a: Uint<BITS, LIMBS>) -> Uint<BITS, LIMBS> {
@@ -109,17 +112,33 @@ pub(crate) fn check_field<const BITS: usize, const LIMBS: usize>(
 ) -> Fq<BITS, LIMBS> {
     assert!(p.bit(0), "{name}: modulus must be odd");
     let f = Fq::new(p);
-    assert_eq!(f.inv.wrapping_mul(p.as_limbs()[0]), u64::MAX, "{name}: bad Montgomery inv");
+    assert_eq!(
+        f.inv.wrapping_mul(p.as_limbs()[0]),
+        u64::MAX,
+        "{name}: bad Montgomery inv"
+    );
     let a = p.wrapping_sub(Uint::from(5u64));
     let b = (p >> 1usize).wrapping_add(Uint::from(7u64));
-    assert_eq!(f.from_mont(f.to_mont(a)), a, "{name}: Montgomery round-trip");
+    assert_eq!(
+        f.from_mont(f.to_mont(a)),
+        a,
+        "{name}: Montgomery round-trip"
+    );
     assert_eq!(
         f.mul(f.to_mont(a), f.to_mont(b)),
         f.to_mont(a.mul_mod(b, p)),
         "{name}: mul_redc disagrees with mul_mod"
     );
-    assert_eq!(f.sqr(f.to_mont(a)), f.mul(f.to_mont(a), f.to_mont(a)), "{name}: square_redc");
-    assert_eq!(f.mul(f.inv(f.to_mont(b)), f.to_mont(b)), f.r1, "{name}: Montgomery inverse");
+    assert_eq!(
+        f.sqr(f.to_mont(a)),
+        f.mul(f.to_mont(a), f.to_mont(a)),
+        "{name}: square_redc"
+    );
+    assert_eq!(
+        f.mul(f.inv(f.to_mont(b)), f.to_mont(b)),
+        f.r1,
+        "{name}: Montgomery inverse"
+    );
     f
 }
 
@@ -133,18 +152,30 @@ fn bench_field<const BITS: usize, const LIMBS: usize>(
     let reduced = move || Uint::<BITS, LIMBS>::arbitrary().prop_map(move |x| x.reduce_mod(p));
     let pair = move || (reduced(), reduced());
 
-    bench_arbitrary_with(criterion, &format!("fields/{name}/mul_redc"), pair(), move |(a, b)| {
-        f.mul(a, b)
-    });
-    bench_arbitrary_with(criterion, &format!("fields/{name}/square_redc"), reduced(), move |a| {
-        f.sqr(a)
-    });
-    bench_arbitrary_with(criterion, &format!("fields/{name}/add_mod"), pair(), move |(a, b)| {
-        a.add_mod(b, p)
-    });
-    bench_arbitrary_with(criterion, &format!("fields/{name}/inv_mod"), reduced(), move |a| {
-        a.inv_mod(p)
-    });
+    bench_arbitrary_with(
+        criterion,
+        &format!("fields/{name}/mul_redc"),
+        pair(),
+        move |(a, b)| f.mul(a, b),
+    );
+    bench_arbitrary_with(
+        criterion,
+        &format!("fields/{name}/square_redc"),
+        reduced(),
+        move |a| f.sqr(a),
+    );
+    bench_arbitrary_with(
+        criterion,
+        &format!("fields/{name}/add_mod"),
+        pair(),
+        move |(a, b)| a.add_mod(b, p),
+    );
+    bench_arbitrary_with(
+        criterion,
+        &format!("fields/{name}/inv_mod"),
+        reduced(),
+        move |a| a.inv_mod(p),
+    );
     // Real fixed exponents: Fermat inversion a^(p−2), point-decompression sqrt
     // a^((p+1)/4) (p ≡ 3 mod 4 only), and the RSA verify exponent 65537.
     let fermat = p.wrapping_sub(Uint::from(2u64));

--- a/benches/benches/fields.rs
+++ b/benches/benches/fields.rs
@@ -123,17 +123,65 @@ pub(crate) fn check_field<const BITS: usize, const LIMBS: usize>(
     f
 }
 
+fn bench_field<const BITS: usize, const LIMBS: usize>(
+    criterion: &mut Criterion,
+    name: &str,
+    p: Uint<BITS, LIMBS>,
+    sqrt: bool,
+) {
+    let f = check_field(name, p);
+    let reduced = move || Uint::<BITS, LIMBS>::arbitrary().prop_map(move |x| x.reduce_mod(p));
+    let pair = move || (reduced(), reduced());
+
+    bench_arbitrary_with(criterion, &format!("fields/{name}/mul_redc"), pair(), move |(a, b)| {
+        f.mul(a, b)
+    });
+    bench_arbitrary_with(criterion, &format!("fields/{name}/square_redc"), reduced(), move |a| {
+        f.sqr(a)
+    });
+    bench_arbitrary_with(criterion, &format!("fields/{name}/add_mod"), pair(), move |(a, b)| {
+        a.add_mod(b, p)
+    });
+    bench_arbitrary_with(criterion, &format!("fields/{name}/inv_mod"), reduced(), move |a| {
+        a.inv_mod(p)
+    });
+    // Real fixed exponents: Fermat inversion a^(p−2), point-decompression sqrt
+    // a^((p+1)/4) (p ≡ 3 mod 4 only), and the RSA verify exponent 65537.
+    let fermat = p.wrapping_sub(Uint::from(2u64));
+    bench_arbitrary_with(
+        criterion,
+        &format!("fields/{name}/pow_mod/fermat"),
+        reduced(),
+        move |a| a.pow_mod(fermat, p),
+    );
+    if sqrt {
+        let e = (p >> 2usize).wrapping_add(Uint::ONE);
+        bench_arbitrary_with(
+            criterion,
+            &format!("fields/{name}/pow_mod/sqrt"),
+            reduced(),
+            move |a| a.pow_mod(e, p),
+        );
+    }
+    bench_arbitrary_with(
+        criterion,
+        &format!("fields/{name}/pow_mod/e65537"),
+        reduced(),
+        move |a| a.pow_mod(Uint::from(65537u64), p),
+    );
+}
+
 pub fn group(criterion: &mut Criterion) {
-    let _ = criterion;
-    check_field("secp256k1_p", SECP256K1_P);
-    check_field("secp256k1_n", SECP256K1_N);
-    check_field("p256_p", P256_P);
-    check_field("p256_n", P256_N);
-    check_field("bn254_p", BN254_P);
-    check_field("bn254_r", BN254_R);
-    check_field("bls12_381_p", BLS12_381_P);
-    check_field("bls12_381_r", BLS12_381_R);
-    check_field("bls12_377_p", BLS12_377_P);
-    check_field("bls12_377_r", BLS12_377_R);
-    check_field("csidh512_p", CSIDH512_P);
+    bench_field(criterion, "secp256k1_p", SECP256K1_P, true);
+    bench_field(criterion, "secp256k1_n", SECP256K1_N, false);
+    bench_field(criterion, "p256_p", P256_P, true);
+    bench_field(criterion, "p256_n", P256_N, false);
+    bench_field(criterion, "bn254_p", BN254_P, true);
+    bench_field(criterion, "bn254_r", BN254_R, false);
+    bench_field(criterion, "bls12_381_p", BLS12_381_P, true);
+    bench_field(criterion, "bls12_381_r", BLS12_381_R, false);
+    // BLS12-377 p ≡ 1 (mod 4): the (p+1)/4 sqrt exponent does not apply.
+    bench_field(criterion, "bls12_377_p", BLS12_377_P, false);
+    bench_field(criterion, "bls12_377_r", BLS12_377_R, false);
+    bench_field(criterion, "csidh512_p", CSIDH512_P, true);
 }

--- a/benches/benches/latency.rs
+++ b/benches/benches/latency.rs
@@ -1,0 +1,102 @@
+//! Latency-chain benchmarks: each measurement is `CHAIN` applications of an
+//! op where the output feeds the next input, so the CPU cannot overlap
+//! iterations. This measures the *critical-path latency* of an op — the cost
+//! that matters when its result feeds control or data flow (pow_mod ladders,
+//! comparison-then-branch) — which throughput-style benches and CodSpeed's
+//! instruction counting are both blind to.
+//!
+//! Reported time ≈ CHAIN × per-op latency; divide by `CHAIN` (64).
+
+use super::fields::{Fq, BLS12_381_P, SECP256K1_P, U256};
+use crate::prelude::*;
+
+const CHAIN: usize = 64;
+
+pub fn group(criterion: &mut Criterion) {
+    // Plain wrapping ops. black_box pins the intermediate so the loop cannot
+    // be reassociated or folded; it adds ~1 register move per link.
+    bench_arbitrary_with(criterion, "chained/mul/256", <(U256, U256)>::arbitrary(), |(mut x, y)| {
+        let y = y | U256::ONE;
+        for _ in 0..CHAIN {
+            x = black_box(x.wrapping_mul(y));
+        }
+        x
+    });
+    bench_arbitrary_with(criterion, "chained/add/256", <(U256, U256)>::arbitrary(), |(mut x, y)| {
+        for _ in 0..CHAIN {
+            x = black_box(x.wrapping_add(y));
+        }
+        x
+    });
+
+    // Comparison ops: the boolean result feeds the next value, modeling
+    // compare-then-act code. The +1/+2 depends on the comparison, so the
+    // dependency is enforced without black_box.
+    bench_arbitrary_with(criterion, "chained/eq/256", <(U256, U256)>::arbitrary(), |(mut x, y)| {
+        for _ in 0..CHAIN {
+            let e = (x == y) as u64;
+            x = x.wrapping_add(U256::from(e + 1));
+        }
+        x
+    });
+    bench_arbitrary_with(criterion, "chained/is_zero/256", U256::arbitrary(), |mut x| {
+        for _ in 0..CHAIN {
+            let z = x.is_zero() as u64;
+            x = x.wrapping_add(U256::from(z + 1));
+        }
+        x
+    });
+
+    // Montgomery kernels: x = f(x, y) is exactly the pow_mod inner loop.
+    chained_redc(criterion, "secp256k1_p", SECP256K1_P);
+    chained_redc(criterion, "bls12_381_p", BLS12_381_P);
+
+    let p = SECP256K1_P;
+    bench_arbitrary_with(
+        criterion,
+        "chained/add_mod/secp256k1_p",
+        (reduced(p), reduced(p)),
+        move |(mut x, y)| {
+            for _ in 0..CHAIN {
+                x = x.add_mod(y, p);
+            }
+            x
+        },
+    );
+}
+
+fn reduced<const BITS: usize, const LIMBS: usize>(
+    p: Uint<BITS, LIMBS>,
+) -> impl Strategy<Value = Uint<BITS, LIMBS>> {
+    Uint::arbitrary().prop_map(move |x| x.reduce_mod(p))
+}
+
+fn chained_redc<const BITS: usize, const LIMBS: usize>(
+    criterion: &mut Criterion,
+    name: &str,
+    p: Uint<BITS, LIMBS>,
+) {
+    let f = Fq::new(p);
+    bench_arbitrary_with(
+        criterion,
+        &format!("chained/mul_redc/{name}"),
+        (reduced(p), reduced(p)),
+        move |(mut x, y)| {
+            for _ in 0..CHAIN {
+                x = f.mul(x, y);
+            }
+            x
+        },
+    );
+    bench_arbitrary_with(
+        criterion,
+        &format!("chained/square_redc/{name}"),
+        reduced(p),
+        move |mut x| {
+            for _ in 0..CHAIN {
+                x = f.sqr(x);
+            }
+            x
+        },
+    );
+}

--- a/benches/benches/latency.rs
+++ b/benches/benches/latency.rs
@@ -42,30 +42,8 @@ pub fn group(criterion: &mut Criterion) {
     // Comparison ops: the boolean result feeds the next value, modeling
     // compare-then-act code. The +1/+2 depends on the comparison, so the
     // dependency is enforced without black_box.
-    bench_arbitrary_with(
-        criterion,
-        "chained/eq/256",
-        <(U256, U256)>::arbitrary(),
-        |(mut x, y)| {
-            for _ in 0..CHAIN {
-                let e = (x == y) as u64;
-                x = x.wrapping_add(U256::from(e + 1));
-            }
-            x
-        },
-    );
-    bench_arbitrary_with(
-        criterion,
-        "chained/is_zero/256",
-        U256::arbitrary(),
-        |mut x| {
-            for _ in 0..CHAIN {
-                let z = x.is_zero() as u64;
-                x = x.wrapping_add(U256::from(z + 1));
-            }
-            x
-        },
-    );
+    chained_cmp::<256, 4>(criterion);
+    chained_cmp::<512, 8>(criterion);
 
     // Montgomery kernels: x = f(x, y) is exactly the pow_mod inner loop.
     chained_redc(criterion, "secp256k1_p", SECP256K1_P);
@@ -79,6 +57,58 @@ pub fn group(criterion: &mut Criterion) {
         move |(mut x, y)| {
             for _ in 0..CHAIN {
                 x = x.add_mod(y, p);
+            }
+            x
+        },
+    );
+}
+
+fn chained_cmp<const BITS: usize, const LIMBS: usize>(criterion: &mut Criterion) {
+    type U<const BITS: usize, const LIMBS: usize> = Uint<BITS, LIMBS>;
+    bench_arbitrary_with(
+        criterion,
+        &format!("chained/eq/{BITS}"),
+        <(U<BITS, LIMBS>, U<BITS, LIMBS>)>::arbitrary(),
+        |(mut x, y)| {
+            for _ in 0..CHAIN {
+                let e = (x == y) as u64;
+                x = x.wrapping_add(U::from(e + 1));
+            }
+            x
+        },
+    );
+    bench_arbitrary_with(
+        criterion,
+        &format!("chained/const_eq/{BITS}"),
+        <(U<BITS, LIMBS>, U<BITS, LIMBS>)>::arbitrary(),
+        |(mut x, y)| {
+            for _ in 0..CHAIN {
+                let e = x.const_eq(&y) as u64;
+                x = x.wrapping_add(U::from(e + 1));
+            }
+            x
+        },
+    );
+    bench_arbitrary_with(
+        criterion,
+        &format!("chained/is_zero/{BITS}"),
+        U::<BITS, LIMBS>::arbitrary(),
+        |mut x| {
+            for _ in 0..CHAIN {
+                let z = x.is_zero() as u64;
+                x = x.wrapping_add(U::from(z + 1));
+            }
+            x
+        },
+    );
+    bench_arbitrary_with(
+        criterion,
+        &format!("chained/const_is_zero/{BITS}"),
+        U::<BITS, LIMBS>::arbitrary(),
+        |mut x| {
+            for _ in 0..CHAIN {
+                let z = x.const_is_zero() as u64;
+                x = x.wrapping_add(U::from(z + 1));
             }
             x
         },

--- a/benches/benches/latency.rs
+++ b/benches/benches/latency.rs
@@ -7,7 +7,7 @@
 //!
 //! Reported time ≈ CHAIN × per-op latency; divide by `CHAIN` (64).
 
-use super::fields::{Fq, BLS12_381_P, SECP256K1_P, U256};
+use super::fields::{BLS12_381_P, Fq, SECP256K1_P, U256};
 use crate::prelude::*;
 
 const CHAIN: usize = 64;
@@ -15,37 +15,57 @@ const CHAIN: usize = 64;
 pub fn group(criterion: &mut Criterion) {
     // Plain wrapping ops. black_box pins the intermediate so the loop cannot
     // be reassociated or folded; it adds ~1 register move per link.
-    bench_arbitrary_with(criterion, "chained/mul/256", <(U256, U256)>::arbitrary(), |(mut x, y)| {
-        let y = y | U256::ONE;
-        for _ in 0..CHAIN {
-            x = black_box(x.wrapping_mul(y));
-        }
-        x
-    });
-    bench_arbitrary_with(criterion, "chained/add/256", <(U256, U256)>::arbitrary(), |(mut x, y)| {
-        for _ in 0..CHAIN {
-            x = black_box(x.wrapping_add(y));
-        }
-        x
-    });
+    bench_arbitrary_with(
+        criterion,
+        "chained/mul/256",
+        <(U256, U256)>::arbitrary(),
+        |(mut x, y)| {
+            let y = y | U256::ONE;
+            for _ in 0..CHAIN {
+                x = black_box(x.wrapping_mul(y));
+            }
+            x
+        },
+    );
+    bench_arbitrary_with(
+        criterion,
+        "chained/add/256",
+        <(U256, U256)>::arbitrary(),
+        |(mut x, y)| {
+            for _ in 0..CHAIN {
+                x = black_box(x.wrapping_add(y));
+            }
+            x
+        },
+    );
 
     // Comparison ops: the boolean result feeds the next value, modeling
     // compare-then-act code. The +1/+2 depends on the comparison, so the
     // dependency is enforced without black_box.
-    bench_arbitrary_with(criterion, "chained/eq/256", <(U256, U256)>::arbitrary(), |(mut x, y)| {
-        for _ in 0..CHAIN {
-            let e = (x == y) as u64;
-            x = x.wrapping_add(U256::from(e + 1));
-        }
-        x
-    });
-    bench_arbitrary_with(criterion, "chained/is_zero/256", U256::arbitrary(), |mut x| {
-        for _ in 0..CHAIN {
-            let z = x.is_zero() as u64;
-            x = x.wrapping_add(U256::from(z + 1));
-        }
-        x
-    });
+    bench_arbitrary_with(
+        criterion,
+        "chained/eq/256",
+        <(U256, U256)>::arbitrary(),
+        |(mut x, y)| {
+            for _ in 0..CHAIN {
+                let e = (x == y) as u64;
+                x = x.wrapping_add(U256::from(e + 1));
+            }
+            x
+        },
+    );
+    bench_arbitrary_with(
+        criterion,
+        "chained/is_zero/256",
+        U256::arbitrary(),
+        |mut x| {
+            for _ in 0..CHAIN {
+                let z = x.is_zero() as u64;
+                x = x.wrapping_add(U256::from(z + 1));
+            }
+            x
+        },
+    );
 
     // Montgomery kernels: x = f(x, y) is exactly the pow_mod inner loop.
     chained_redc(criterion, "secp256k1_p", SECP256K1_P);

--- a/benches/benches/mod.rs
+++ b/benches/benches/mod.rs
@@ -4,6 +4,7 @@ mod base_convert;
 mod bits;
 mod cmp;
 mod div;
+mod fields;
 mod fmt;
 mod from;
 mod log;
@@ -25,6 +26,7 @@ pub fn group(c: &mut criterion::Criterion) {
     log::group(c);
     root::group(c);
     modular::group(c);
+    fields::group(c);
 
     cmp::group(c);
 

--- a/benches/benches/mod.rs
+++ b/benches/benches/mod.rs
@@ -4,6 +4,7 @@ mod base_convert;
 mod bits;
 mod cmp;
 mod curves;
+mod distributions;
 mod div;
 mod fields;
 mod fmt;
@@ -33,6 +34,7 @@ pub fn group(c: &mut criterion::Criterion) {
     curves::group(c);
 
     cmp::group(c);
+    distributions::group(c);
 
     base_convert::group(c);
     from::group(c);

--- a/benches/benches/mod.rs
+++ b/benches/benches/mod.rs
@@ -3,6 +3,7 @@ mod algorithms;
 mod base_convert;
 mod bits;
 mod cmp;
+mod curves;
 mod div;
 mod fields;
 mod fmt;
@@ -29,6 +30,7 @@ pub fn group(c: &mut criterion::Criterion) {
     modular::group(c);
     fields::group(c);
     latency::group(c);
+    curves::group(c);
 
     cmp::group(c);
 

--- a/benches/benches/mod.rs
+++ b/benches/benches/mod.rs
@@ -7,6 +7,7 @@ mod div;
 mod fields;
 mod fmt;
 mod from;
+mod latency;
 mod log;
 mod modular;
 mod mul;
@@ -27,6 +28,7 @@ pub fn group(c: &mut criterion::Criterion) {
     root::group(c);
     modular::group(c);
     fields::group(c);
+    latency::group(c);
 
     cmp::group(c);
 

--- a/benches/benches/prelude.rs
+++ b/benches/benches/prelude.rs
@@ -130,6 +130,10 @@ fn manual_batch<T, U>(
 
 #[allow(dead_code)]
 fn get_batch_size(name: &str) -> usize {
+    // Chained and composite-kernel benches do 16-64 core ops per call; batch less.
+    if name.starts_with("chained/") || name.starts_with("curves/") {
+        return 100;
+    }
     let size = name.split('/').flat_map(str::parse::<usize>).max();
     if name.contains("pow") {
         if size >= Some(4096) { 1 } else { 100 }

--- a/src/algorithms/mul_redc.rs
+++ b/src/algorithms/mul_redc.rs
@@ -257,6 +257,9 @@ mod test {
 
     #[test]
     fn test_square_redc() {
+        // `NON_ZERO` covers N ∈ {1, 2, 3, 4, 6, 8, 64}; 320/448 add the odd
+        // widths 5 and 7 (real triangular structure in the specialized path)
+        // and 576 the first width dispatched to the `mul_redc` fallback.
         const_for!(BITS in NON_ZERO if BITS >= 16 {
             const LIMBS: usize = nlimbs(BITS);
             type U = Uint<BITS, LIMBS>;
@@ -272,6 +275,60 @@ mod test {
 
                 prop_assert_eq!(result, expected);
             });
+        });
+        const_for!(BITS in [320, 448, 576] {
+            const LIMBS: usize = nlimbs(BITS);
+            type U = Uint<BITS, LIMBS>;
+            proptest!(|(mut a: U, mut m: U)| {
+                m |= U::from(1_u64); // Make sure m is odd.
+                a %= m; // Make sure a is less than m.
+                let a = *a.as_limbs();
+                let m = *m.as_limbs();
+                let inv = U64::from(m[0]).inv_ring().unwrap().neg().as_limbs()[0];
+
+                let result = mul_base(square_redc(a, m, inv), m);
+                let expected = modmul(a, a, m);
+
+                prop_assert_eq!(result, expected);
+            });
+        });
+    }
+
+    #[test]
+    fn test_square_redc_carry_saturation() {
+        // The single-word-carry design rests on sums that reach exactly
+        // 2^65 - 1 — the ceiling of a `(u64, bool)` accumulator — in the
+        // doubling pass and the reduction's final add. Saturating them
+        // requires modulus limbs at u64::MAX together with `a` near
+        // `m - 1`, a corner uniform-random moduli cannot reach; pin it
+        // with directed all-ones-shaped moduli at every specialized width
+        // plus the first fallback width.
+        const_for!(BITS in [64, 128, 192, 256, 320, 384, 448, 512, 576] {
+            const LIMBS: usize = nlimbs(BITS);
+            type U = Uint<BITS, LIMBS>;
+            // 2^(64N) - 1: every limb saturated.
+            let all_ones = U::MAX;
+            // 2^(64N) - 2^64 + 1: saturated except the bottom limb.
+            let mut low_one = U::MAX;
+            unsafe { low_one.as_limbs_mut()[0] = 1 };
+            // Minimal top limb over saturated low limbs.
+            let mut small_top = U::MAX;
+            unsafe { small_top.as_limbs_mut()[LIMBS - 1] = 1 };
+            for m in [all_ones, low_one, small_top] {
+                let inv = U64::from(m.as_limbs()[0]).inv_ring().unwrap().neg().as_limbs()[0];
+                for a in [
+                    m.wrapping_sub(U::from(1_u64)),
+                    m.wrapping_sub(U::from(2_u64)),
+                    m >> 1,
+                    U::from(1_u64),
+                ] {
+                    let a = *(a % m).as_limbs();
+                    let m = *m.as_limbs();
+                    let squared = square_redc(a, m, inv);
+                    assert_eq!(squared, mul_redc(a, a, m, inv));
+                    assert_eq!(mul_base(squared, m), modmul(a, a, m));
+                }
+            }
         });
     }
 }

--- a/src/algorithms/mul_redc.rs
+++ b/src/algorithms/mul_redc.rs
@@ -135,7 +135,7 @@ pub fn square_redc<const N: usize>(a: [u64; N], modulus: [u64; N], inv: u64) -> 
     // limb i + N + 1 — exactly the next round's final add, so `carry_top`
     // hands it forward.
     let mut carry_top = false;
-    for i in 0..N {
+    for &hi_limb in &hi {
         let m = lo[0].wrapping_mul(inv);
         let (value, mut carry) = carrying_mul_add(m, modulus[0], lo[0], 0);
         debug_assert_eq!(value, 0);
@@ -144,7 +144,7 @@ pub fn square_redc<const N: usize>(a: [u64; N], modulus: [u64; N], inv: u64) -> 
             lo[j - 1] = value;
             carry = next_carry;
         }
-        let (value, next_carry) = carrying_add(hi[i], carry, carry_top);
+        let (value, next_carry) = carrying_add(hi_limb, carry, carry_top);
         lo[N - 1] = value;
         carry_top = next_carry;
     }

--- a/src/algorithms/mul_redc.rs
+++ b/src/algorithms/mul_redc.rs
@@ -67,60 +67,108 @@ pub fn mul_redc<const N: usize>(a: [u64; N], b: [u64; N], modulus: [u64; N], inv
 /// Requires that `a` is less than `modulus`.
 #[inline]
 #[must_use]
-#[allow(clippy::cast_possible_truncation)]
 pub fn square_redc<const N: usize>(a: [u64; N], modulus: [u64; N], inv: u64) -> [u64; N] {
     debug_assert_eq!(inv.wrapping_mul(modulus[0]), u64::MAX);
     debug_assert_eq!(cmp(&a, &modulus), Ordering::Less);
 
-    let mut result = [0; N];
-    let mut carry_outer = 0;
+    // The specialized path below beats the plain multiply only while it
+    // compiles to straight-line code; past 8 limbs the loops no longer
+    // unroll and the multiply's fused inner loop wins (measured on Apple
+    // M-series and AMD Zen 2).
+    if N > 8 {
+        return mul_redc(a, a, modulus, inv);
+    }
+
+    // The 2N-limb square is accumulated in `(lo, hi)`, `lo` holding limbs
+    // 0..N and `hi` limbs N..2N. All loops below run a constant `N`
+    // iterations with the triangular structure expressed as guards, and all
+    // carries fit u64 or bool, so the code fully unrolls and the carries
+    // lower to flag registers. (A single loop with data-dependent trip count
+    // or a two-word carry defeats both.)
+    let mut lo = [0; N];
+    let mut hi = [0; N];
+
+    // Cross products, undoubled: sum of a[i] * a[j] for i < j.
     for i in 0..N {
-        // Add limb product
-        let (value, mut carry_lo) = carrying_mul_add(a[i], a[i], result[i], 0);
-        let mut carry_hi = false;
-        result[i] = value;
-        for j in (i + 1)..N {
-            let (value, next_carry_lo, next_carry_hi) =
-                carrying_double_mul_add(a[i], a[j], result[j], carry_lo, carry_hi);
-            result[j] = value;
-            carry_lo = next_carry_lo;
-            carry_hi = next_carry_hi;
+        let mut carry = 0;
+        for j in 0..N {
+            if j > i {
+                let (value, next_carry) = carrying_mul_add(a[i], a[j], get(&lo, &hi, i + j), carry);
+                set(&mut lo, &mut hi, i + j, value);
+                carry = next_carry;
+            }
         }
-
-        // Add m times modulus to result and shift one limb
-        let m = result[0].wrapping_mul(inv);
-        let (value, mut carry) = carrying_mul_add(m, modulus[0], result[0], 0);
-        debug_assert_eq!(value, 0);
-        for j in 1..N {
-            let (value, next_carry) = carrying_mul_add(modulus[j], m, result[j], carry);
-            result[j - 1] = value;
-            carry = next_carry;
-        }
-
-        // Add carries
-        if modulus[N - 1] >= 0x3fff_ffff_ffff_ffff {
-            let wide = (carry_outer as u128)
-                .wrapping_add(carry_lo as u128)
-                .wrapping_add((carry_hi as u128) << 64)
-                .wrapping_add(carry as u128);
-            result[N - 1] = wide as u64;
-
-            // Note carry_outer can be {0, 1, 2}.
-            carry_outer = (wide >> 64) as u64;
-            debug_assert!(carry_outer <= 2);
-        } else {
-            // `carry_outer` and `carry_hi` are always zero.
-            debug_assert!(!carry_hi);
-            debug_assert_eq!(carry_outer, 0);
-            let (value, carry) = carry_lo.overflowing_add(carry);
-            debug_assert!(!carry);
-            result[N - 1] = value;
+        if i + 1 < N {
+            // Row i ends at limb i + N - 1; its carry lands in fresh limb
+            // i + N. The last row is empty and carries nothing.
+            set(&mut lo, &mut hi, i + N, carry);
         }
     }
 
-    // Compute reduced product.
-    debug_assert!(carry_outer <= 1);
-    reduce1_carry(result, modulus, carry_outer > 0)
+    // Double the cross products (their sum is less than 2^(128N - 1), so
+    // the shift cannot overflow) and add the diagonal squares, in one pass.
+    // Limb pairs (2i, 2i + 1) are contiguous, so a single shift-out bit and
+    // a single carry chain cover the whole sweep.
+    let mut msb = 0;
+    let mut carry = false;
+    for (i, &limb) in a.iter().enumerate() {
+        let (square_lo, square_hi) = carrying_mul_add(limb, limb, 0, 0);
+        let value = get(&lo, &hi, 2 * i);
+        let (doubled, next_msb) = ((value << 1) | msb, value >> 63);
+        let (value, next_carry) = carrying_add(doubled, square_lo, carry);
+        set(&mut lo, &mut hi, 2 * i, value);
+        msb = next_msb;
+        let value = get(&lo, &hi, 2 * i + 1);
+        let (doubled, next_msb) = ((value << 1) | msb, value >> 63);
+        let (value, next_carry) = carrying_add(doubled, square_hi, next_carry);
+        set(&mut lo, &mut hi, 2 * i + 1, value);
+        msb = next_msb;
+        carry = next_carry;
+    }
+    debug_assert_eq!(msb, 0);
+    debug_assert!(!carry);
+
+    // Montgomery reduction, with `lo` as a sliding window: each round clears
+    // the window's bottom limb by adding m * modulus, shifts the window down
+    // one limb, and pulls in the next limb of `hi`. In fixed-index terms,
+    // round i's final add lands at limb i + N, whose carry-out belongs to
+    // limb i + N + 1 — exactly the next round's final add, so `carry_top`
+    // hands it forward.
+    let mut carry_top = false;
+    for i in 0..N {
+        let m = lo[0].wrapping_mul(inv);
+        let (value, mut carry) = carrying_mul_add(m, modulus[0], lo[0], 0);
+        debug_assert_eq!(value, 0);
+        for j in 1..N {
+            let (value, next_carry) = carrying_mul_add(modulus[j], m, lo[j], carry);
+            lo[j - 1] = value;
+            carry = next_carry;
+        }
+        let (value, next_carry) = carrying_add(hi[i], carry, carry_top);
+        lo[N - 1] = value;
+        carry_top = next_carry;
+    }
+
+    // The reduced square is a^2 / 2^(64N) + (sum of m_i * modulus) / 2^(64N)
+    // < modulus^2 / 2^(64N) + modulus < 2 * modulus, so one conditional
+    // subtraction (with `carry_top` as the 2^(64N) bit) completes it.
+    reduce1_carry(lo, modulus, carry_top)
+}
+
+/// Reads limb `i` of the 2N-limb value split across `lo` and `hi`.
+#[inline(always)]
+fn get<const N: usize>(lo: &[u64; N], hi: &[u64; N], i: usize) -> u64 {
+    if i < N { lo[i] } else { hi[i - N] }
+}
+
+/// Writes limb `i` of the 2N-limb value split across `lo` and `hi`.
+#[inline(always)]
+fn set<const N: usize>(lo: &mut [u64; N], hi: &mut [u64; N], i: usize, value: u64) {
+    if i < N {
+        lo[i] = value;
+    } else {
+        hi[i - N] = value;
+    }
 }
 
 #[inline]
@@ -151,27 +199,6 @@ fn sub<const N: usize>(lhs: [u64; N], rhs: [u64; N]) -> ([u64; N], bool) {
 #[allow(clippy::cast_possible_truncation)]
 fn carrying_mul_add(lhs: u64, rhs: u64, add: u64, carry: u64) -> (u64, u64) {
     DW::split(DW::muladd2(lhs, rhs, add, carry))
-}
-
-/// Compute `2 * lhs * rhs + add + carry_lo + 2^64 * carry_hi`.
-/// The output can not overflow for any input values.
-#[inline]
-#[must_use]
-#[allow(clippy::cast_possible_truncation)]
-const fn carrying_double_mul_add(
-    lhs: u64,
-    rhs: u64,
-    add: u64,
-    carry_lo: u64,
-    carry_hi: bool,
-) -> (u64, u64, bool) {
-    let wide = (lhs as u128).wrapping_mul(rhs as u128);
-    let (wide, carry_1) = wide.overflowing_add(wide);
-    let carries = (add as u128)
-        .wrapping_add(carry_lo as u128)
-        .wrapping_add((carry_hi as u128) << 64);
-    let (wide, carry_2) = wide.overflowing_add(carries);
-    (wide as u64, (wide >> 64) as u64, carry_1 | carry_2)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

`square_redc` was slower than `mul_redc(a, a)` at every width on every architecture tested — 2.05× at 256 bits on Apple M-series, ~1.4× on AMD Zen 2 — when squaring should cost at most a multiply. This PR rewrites it so that it wins (or ties) everywhere, and adds the real-world benchmark suite that found and verifies the problem.

### Root cause

The old implementation did fewer multiplies on paper but compiled to much worse code, for two structural reasons:

1. **The doubled-cross-term inner loop (`for j in (i + 1)..N`) had a data-dependent, triangular trip count**, which LLVM refuses to fully unroll. At N = 4, `mul_redc` compiles to ~400 straight-line branch-free instructions, while the old `square_redc` compiled to a ~105-instruction rolled nested loop — with the loop-invariant `modulus[N - 1]` test re-executed on every outer iteration.
2. **`2·a[i]·a[j] + limb + carry` overflows 128 bits**, forcing a 65-bit `(u64, bool)` carry. A two-word carry cannot live in the flags register, so it was materialized and re-added on every iteration, serializing the whole cross-term chain.

### New algorithm

- Accumulate the **undoubled** upper-triangle cross products with plain `u64` carries; the triangular structure is expressed as guards inside constant-trip loops so everything unrolls and the guards fold away.
- Double the whole 2N-limb product and add the diagonal squares in a single flag-friendly pass.
- Montgomery-reduce with a CIOS-style sliding window (constant indices only), handing the top-limb carry forward across rounds as a single bool.
- For **N > 8** the loops no longer unroll and the specialized path loses its edge, so it falls back to `mul_redc(a, a)` — which measures up to 39% faster there (2048 bits, M-series).

### Benchmarks added

Four new bench groups under `ruint-bench` capture real-world workloads that the existing random-modulus benches miss, and serve as the regression harness for this fix:

- `fields/{field}/{op}` — fixed-modulus kernels over the 11 moduli that dominate real usage (secp256k1 p/n, P-256 p/n, BN254 p/r, BLS12-381 p/r, BLS12-377 p/r, CSIDH-512), including `mul_redc`, `square_redc`, and real fixed exponents (Fermat inversion, sqrt decompression, 65537). Montgomery contexts are self-checked at registration time.
- `chained/{op}/{tag}` — 64-deep serial dependency chains measuring critical-path latency, which throughput benches and instruction counting are both blind to. Includes `const_eq`/`const_is_zero` variants at 256 and 512 bits — the only regression guard for #615's latency-shaped fold fix (cherry-picked here from #617 after it was folded into #615).
- `curves/{curve}/{kernel}` — composite kernels (Jacobian double/add with known-answer checks against 2G/3G, Fp2 mul, 16-bit scalar-mul segment, ECDSA verify prologue, 64-element batch inversion).
- `dist/{op}/{distribution}/256` — comparisons under realistic input distributions (equal/differ-late, 160-bit addresses, small counters) where branchy vs branchless implementations rank differently. Includes `const_eq` variants guarding #615's standalone-throughput tradeoff.

### Measurements

Wall clock via `fields/*/square_redc` (was → now, `mul_redc` for reference):

| width | Apple M-series | AMD Zen 2 |
|---|---|---|
| 256-bit | 25.2 → **12.3 ns** (mul: 14.5) | 32.7 → **23.5 ns** (mul: 23.1) |
| 384-bit | 49.4 → **21.6 ns** (mul: 28.2) | ~61 → **42.0 ns** (mul: 46.7) |
| 512-bit | 72.1 → **37.9 ns** (mul: 47.6) | ~110 → **79.5 ns** (mul: 82.1) |

Dependent-chain latency (`chained/square_redc/*`) improves similarly (e.g. 384-bit on M-series: 1.56 µs vs mul's 2.07 µs per 64-op chain).

Work counts: exact dynamic instruction counts (callgrind, x86-64) are strictly below both the old code and `mul_redc(a, a)` at 4/6/8 limbs (e.g. 273 vs 327 vs 422 instructions per op at 256 bits), so CodSpeed's instrumentation metric improves as well. Crossover sweep (synthetic moduli at 5, 7, 16, 32 limbs) confirms the N ≤ 8 specialization threshold on both architectures.

Correctness: existing proptest suites (`algorithms::mul_redc::test_square_redc`, `modular::tests::test_square_redc`) cover 16–4096 bits against the division-based reference, now extended to 320/448 bits (the odd specialized widths N = 5, 7) and 576 bits (the first fallback width). A directed carry-saturation test squares `a = m - 1` under all-ones-shaped moduli at every N ≤ 9, driving the `(u64, bool)` carry sums to their exact `2^65 - 1` ceiling — the corner uniform-random proptests cannot reach and the classic hiding spot for a lost squaring carry. Green on stable and with the `nightly` feature. All bench groups run registration-time self-checks (Montgomery round-trips, secp256k1 known-answer points, algebraic identities) so a wrong constant panics instead of benchmarking garbage.

## ⚠️ Blocker — why this is a draft

**Stacked on #615** (`prestwich/const-eq-dw`): this PR is based on and targets that branch, not `main`, and is rebased onto its current tip (the XOR/OR-fold `const_eq` absorbed from #617, plus its cutoff-boundary tests). It must not merge until #615 lands, then be retargeted to `main`. The `square_redc` work itself is functionally independent (no file overlap) and could be rebased onto `main` directly if #615 stalls — but the `chained/const_eq` and `dist/const_eq` bench guards in this PR exist to protect #615's fix, so the two should land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJ4S2Ns5cyvmkTFJ7mgrWE
