### PR TITLE
perf: scalar-friendly const_eq fold for x86-64 dependent-use latency

### DIFF
--- a/benches/benches/cmp.rs
+++ b/benches/benches/cmp.rs
@@ -4,7 +4,11 @@ pub fn group(criterion: &mut Criterion) {
     const_for!(BITS in BENCH {
         const LIMBS: usize = nlimbs(BITS);
         bench_unop::<BITS, LIMBS, _>(criterion, "is_zero", |a| a.is_zero());
+        bench_unop::<BITS, LIMBS, _>(criterion, "const_is_zero", |a| a.const_is_zero());
+        bench_unop::<BITS, LIMBS, _>(criterion, "const_is_zero_dw", |a| a.const_is_zero_dw());
         bench_binop::<BITS, LIMBS, _>(criterion, "eq", |a, b| a == b);
+        bench_binop::<BITS, LIMBS, _>(criterion, "const_eq", |a, b| a.const_eq(&b));
+        bench_binop::<BITS, LIMBS, _>(criterion, "const_eq_dw", |a, b| a.const_eq_dw(&b));
         bench_binop::<BITS, LIMBS, _>(criterion, "cmp", |a, b| a.cmp(&b));
         bench_binop::<BITS, LIMBS, _>(criterion, "lt", |a, b| a < b);
         bench_binop::<BITS, LIMBS, _>(criterion, "gt", |a, b| a > b);

--- a/benches/benches/cmp.rs
+++ b/benches/benches/cmp.rs
@@ -5,10 +5,8 @@ pub fn group(criterion: &mut Criterion) {
         const LIMBS: usize = nlimbs(BITS);
         bench_unop::<BITS, LIMBS, _>(criterion, "is_zero", |a| a.is_zero());
         bench_unop::<BITS, LIMBS, _>(criterion, "const_is_zero", |a| a.const_is_zero());
-        bench_unop::<BITS, LIMBS, _>(criterion, "const_is_zero_dw", |a| a.const_is_zero_dw());
         bench_binop::<BITS, LIMBS, _>(criterion, "eq", |a, b| a == b);
         bench_binop::<BITS, LIMBS, _>(criterion, "const_eq", |a, b| a.const_eq(&b));
-        bench_binop::<BITS, LIMBS, _>(criterion, "const_eq_dw", |a, b| a.const_eq_dw(&b));
         bench_binop::<BITS, LIMBS, _>(criterion, "cmp", |a, b| a.cmp(&b));
         bench_binop::<BITS, LIMBS, _>(criterion, "lt", |a, b| a < b);
         bench_binop::<BITS, LIMBS, _>(criterion, "gt", |a, b| a > b);

--- a/benches/benches/curves.rs
+++ b/benches/benches/curves.rs
@@ -5,7 +5,7 @@
 //! pressure, op mix, and memory patterns of real signature/pairing code,
 //! which single-op benches cannot.
 
-use super::fields::{check_field, Fq, BLS12_381_P, SECP256K1_N, SECP256K1_P, U256, U384};
+use super::fields::{BLS12_381_P, Fq, SECP256K1_N, SECP256K1_P, U256, U384, check_field};
 use crate::prelude::*;
 
 const G_X: U256 = uint!(0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798_U256);
@@ -48,7 +48,11 @@ fn jac_double<const BITS: usize, const LIMBS: usize>(
         let t = f.mul(p.y, p.z);
         f.add(t, t)
     };
-    Jac { x: x3, y: y3, z: z3 }
+    Jac {
+        x: x3,
+        y: y3,
+        z: z3,
+    }
 }
 
 /// General addition (EFD add-2007-bl). Requires P ≠ ±Q and both nonzero.
@@ -80,7 +84,11 @@ fn jac_add<const BITS: usize, const LIMBS: usize>(
         f.sub(f.mul(r, f.sub(v, x3)), f.add(t, t))
     };
     let z3 = f.mul(f.sub(f.sub(f.sqr(f.add(p.z, q.z)), z1z1), z2z2), h);
-    Jac { x: x3, y: y3, z: z3 }
+    Jac {
+        x: x3,
+        y: y3,
+        z: z3,
+    }
 }
 
 /// Fp2 = Fp[u]/(u² + 1) multiplication, Karatsuba: 3 muls + 5 add/subs.
@@ -147,7 +155,11 @@ fn to_affine<const BITS: usize, const LIMBS: usize>(
 /// Known-answer checks: a wrong formula or constant panics here.
 fn sanity_checks() {
     let f = check_field("secp256k1_p", SECP256K1_P);
-    let g = Jac { x: f.to_mont(G_X), y: f.to_mont(G_Y), z: f.r1 };
+    let g = Jac {
+        x: f.to_mont(G_X),
+        y: f.to_mont(G_Y),
+        z: f.r1,
+    };
     let g2 = jac_double(&f, g);
     assert_eq!(to_affine(&f, g2), (G2_X, G2_Y), "jac_double: 2G mismatch");
     let g3 = jac_add(&f, g2, g);
@@ -159,13 +171,24 @@ fn sanity_checks() {
         d16 = jac_double(&f, d16);
     }
     let seg = scalar_mul_segment(&f, g, g, 0);
-    assert_eq!(to_affine(&f, seg), to_affine(&f, d16), "scalar_mul_segment: k=0");
+    assert_eq!(
+        to_affine(&f, seg),
+        to_affine(&f, d16),
+        "scalar_mul_segment: k=0"
+    );
 
     // Fp2: (a0 + a1·u)(a0 − a1·u) = a0² + a1², and u·u = −1.
     let f2 = check_field("bls12_381_p", BLS12_381_P);
-    let (a0, a1) = (f2.to_mont(Uint::from(1234u64)), f2.to_mont(Uint::from(5678u64)));
+    let (a0, a1) = (
+        f2.to_mont(Uint::from(1234u64)),
+        f2.to_mont(Uint::from(5678u64)),
+    );
     let conj = fp2_mul(&f2, (a0, a1), (a0, f2.sub(Uint::ZERO, a1)));
-    assert_eq!(conj, (f2.add(f2.sqr(a0), f2.sqr(a1)), Uint::ZERO), "fp2_mul: conjugate");
+    assert_eq!(
+        conj,
+        (f2.add(f2.sqr(a0), f2.sqr(a1)), Uint::ZERO),
+        "fp2_mul: conjugate"
+    );
     let u = (Uint::ZERO, f2.r1);
     assert_eq!(
         fp2_mul(&f2, u, u),
@@ -190,7 +213,11 @@ fn jac_point_strategy<const BITS: usize, const LIMBS: usize>(
     p: Uint<BITS, LIMBS>,
 ) -> impl Strategy<Value = Jac<BITS, LIMBS>> {
     <(Uint<BITS, LIMBS>, Uint<BITS, LIMBS>, Uint<BITS, LIMBS>)>::arbitrary().prop_map(
-        move |(x, y, z)| Jac { x: x.reduce_mod(p), y: y.reduce_mod(p), z: z.reduce_mod(p) },
+        move |(x, y, z)| Jac {
+            x: x.reduce_mod(p),
+            y: y.reduce_mod(p),
+            z: z.reduce_mod(p),
+        },
     )
 }
 
@@ -237,7 +264,11 @@ pub fn group(criterion: &mut Criterion) {
     bench_arbitrary_with(
         criterion,
         "curves/secp256k1/scalar_mul_segment16",
-        (jac_point_strategy(SECP256K1_P), jac_point_strategy(SECP256K1_P), u16::arbitrary()),
+        (
+            jac_point_strategy(SECP256K1_P),
+            jac_point_strategy(SECP256K1_P),
+            u16::arbitrary(),
+        ),
         move |(acc, q, k)| scalar_mul_segment(&f, acc, q, k),
     );
 
@@ -246,11 +277,7 @@ pub fn group(criterion: &mut Criterion) {
     let scalar = move || {
         U256::arbitrary().prop_map(move |x| {
             let x = x.reduce_mod(n);
-            if x.is_zero() {
-                U256::ONE
-            } else {
-                x
-            }
+            if x.is_zero() { U256::ONE } else { x }
         })
     };
     bench_arbitrary_with(
@@ -267,11 +294,7 @@ pub fn group(criterion: &mut Criterion) {
     let nonzero = move || {
         U256::arbitrary().prop_map(move |x| {
             let x = x.reduce_mod(SECP256K1_P);
-            if x.is_zero() {
-                U256::ONE
-            } else {
-                x
-            }
+            if x.is_zero() { U256::ONE } else { x }
         })
     };
     bench_arbitrary_with(

--- a/benches/benches/curves.rs
+++ b/benches/benches/curves.rs
@@ -1,0 +1,139 @@
+//! Composite elliptic-curve kernels built from ruint field primitives:
+//! Jacobian point double/add (secp256k1 and BLS12-381 G1, both a = 0),
+//! Fp2 multiplication, a 16-bit double-and-add scalar segment, the ECDSA
+//! verify scalar prologue, and batch inversion. These exercise the register
+//! pressure, op mix, and memory patterns of real signature/pairing code,
+//! which single-op benches cannot.
+
+use super::fields::{check_field, Fq, BLS12_381_P, SECP256K1_P, U256};
+use crate::prelude::*;
+
+const G_X: U256 = uint!(0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798_U256);
+const G_Y: U256 = uint!(0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8_U256);
+const G2_X: U256 = uint!(0xc6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5_U256);
+const G2_Y: U256 = uint!(0x1ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a_U256);
+const G3_X: U256 = uint!(0xf9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9_U256);
+const G3_Y: U256 = uint!(0x388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e672_U256);
+
+/// Jacobian point (x/z², y/z³), coordinates in Montgomery form.
+#[derive(Clone, Copy, Debug)]
+struct Jac<const BITS: usize, const LIMBS: usize> {
+    x: Uint<BITS, LIMBS>,
+    y: Uint<BITS, LIMBS>,
+    z: Uint<BITS, LIMBS>,
+}
+
+/// Doubling for a = 0 curves (EFD dbl-2009-l).
+fn jac_double<const BITS: usize, const LIMBS: usize>(
+    f: &Fq<BITS, LIMBS>,
+    p: Jac<BITS, LIMBS>,
+) -> Jac<BITS, LIMBS> {
+    let a = f.sqr(p.x);
+    let b = f.sqr(p.y);
+    let c = f.sqr(b);
+    let d = {
+        let t = f.sub(f.sub(f.sqr(f.add(p.x, b)), a), c);
+        f.add(t, t)
+    };
+    let e = f.add(f.add(a, a), a);
+    let ff = f.sqr(e);
+    let x3 = f.sub(ff, f.add(d, d));
+    let c8 = {
+        let c2 = f.add(c, c);
+        let c4 = f.add(c2, c2);
+        f.add(c4, c4)
+    };
+    let y3 = f.sub(f.mul(e, f.sub(d, x3)), c8);
+    let z3 = {
+        let t = f.mul(p.y, p.z);
+        f.add(t, t)
+    };
+    Jac { x: x3, y: y3, z: z3 }
+}
+
+/// General addition (EFD add-2007-bl). Requires P ≠ ±Q and both nonzero.
+fn jac_add<const BITS: usize, const LIMBS: usize>(
+    f: &Fq<BITS, LIMBS>,
+    p: Jac<BITS, LIMBS>,
+    q: Jac<BITS, LIMBS>,
+) -> Jac<BITS, LIMBS> {
+    let z1z1 = f.sqr(p.z);
+    let z2z2 = f.sqr(q.z);
+    let u1 = f.mul(p.x, z2z2);
+    let u2 = f.mul(q.x, z1z1);
+    let s1 = f.mul(f.mul(p.y, q.z), z2z2);
+    let s2 = f.mul(f.mul(q.y, p.z), z1z1);
+    let h = f.sub(u2, u1);
+    let i = {
+        let h2 = f.add(h, h);
+        f.sqr(h2)
+    };
+    let j = f.mul(h, i);
+    let r = {
+        let t = f.sub(s2, s1);
+        f.add(t, t)
+    };
+    let v = f.mul(u1, i);
+    let x3 = f.sub(f.sub(f.sqr(r), j), f.add(v, v));
+    let y3 = {
+        let t = f.mul(s1, j);
+        f.sub(f.mul(r, f.sub(v, x3)), f.add(t, t))
+    };
+    let z3 = f.mul(f.sub(f.sub(f.sqr(f.add(p.z, q.z)), z1z1), z2z2), h);
+    Jac { x: x3, y: y3, z: z3 }
+}
+
+/// Montgomery-form Jacobian point back to plain affine coordinates.
+fn to_affine<const BITS: usize, const LIMBS: usize>(
+    f: &Fq<BITS, LIMBS>,
+    p: Jac<BITS, LIMBS>,
+) -> (Uint<BITS, LIMBS>, Uint<BITS, LIMBS>) {
+    let (x, y, z) = (f.from_mont(p.x), f.from_mont(p.y), f.from_mont(p.z));
+    let zi = z.inv_mod(f.p).unwrap();
+    let zi2 = zi.mul_mod(zi, f.p);
+    (x.mul_mod(zi2, f.p), y.mul_mod(zi2.mul_mod(zi, f.p), f.p))
+}
+
+/// Known-answer checks: a wrong formula or constant panics here.
+fn sanity_checks() {
+    let f = check_field("secp256k1_p", SECP256K1_P);
+    let g = Jac { x: f.to_mont(G_X), y: f.to_mont(G_Y), z: f.r1 };
+    let g2 = jac_double(&f, g);
+    assert_eq!(to_affine(&f, g2), (G2_X, G2_Y), "jac_double: 2G mismatch");
+    let g3 = jac_add(&f, g2, g);
+    assert_eq!(to_affine(&f, g3), (G3_X, G3_Y), "jac_add: 3G mismatch");
+}
+
+fn jac_point_strategy<const BITS: usize, const LIMBS: usize>(
+    p: Uint<BITS, LIMBS>,
+) -> impl Strategy<Value = Jac<BITS, LIMBS>> {
+    <(Uint<BITS, LIMBS>, Uint<BITS, LIMBS>, Uint<BITS, LIMBS>)>::arbitrary().prop_map(
+        move |(x, y, z)| Jac { x: x.reduce_mod(p), y: y.reduce_mod(p), z: z.reduce_mod(p) },
+    )
+}
+
+fn bench_curve<const BITS: usize, const LIMBS: usize>(
+    criterion: &mut Criterion,
+    name: &str,
+    p: Uint<BITS, LIMBS>,
+) {
+    let f = Fq::new(p);
+    bench_arbitrary_with(
+        criterion,
+        &format!("curves/{name}/jac_double"),
+        jac_point_strategy(p),
+        move |pt| jac_double(&f, pt),
+    );
+    bench_arbitrary_with(
+        criterion,
+        &format!("curves/{name}/jac_add"),
+        (jac_point_strategy(p), jac_point_strategy(p)),
+        move |(a, b)| jac_add(&f, a, b),
+    );
+}
+
+pub fn group(criterion: &mut Criterion) {
+    sanity_checks();
+    bench_curve(criterion, "secp256k1", SECP256K1_P);
+    bench_curve(criterion, "bls12_381_g1", BLS12_381_P);
+}

--- a/benches/benches/curves.rs
+++ b/benches/benches/curves.rs
@@ -5,7 +5,7 @@
 //! pressure, op mix, and memory patterns of real signature/pairing code,
 //! which single-op benches cannot.
 
-use super::fields::{check_field, Fq, BLS12_381_P, SECP256K1_P, U256};
+use super::fields::{check_field, Fq, BLS12_381_P, SECP256K1_N, SECP256K1_P, U256, U384};
 use crate::prelude::*;
 
 const G_X: U256 = uint!(0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798_U256);
@@ -83,6 +83,56 @@ fn jac_add<const BITS: usize, const LIMBS: usize>(
     Jac { x: x3, y: y3, z: z3 }
 }
 
+/// Fp2 = Fp[u]/(u² + 1) multiplication, Karatsuba: 3 muls + 5 add/subs.
+fn fp2_mul<const BITS: usize, const LIMBS: usize>(
+    f: &Fq<BITS, LIMBS>,
+    a: (Uint<BITS, LIMBS>, Uint<BITS, LIMBS>),
+    b: (Uint<BITS, LIMBS>, Uint<BITS, LIMBS>),
+) -> (Uint<BITS, LIMBS>, Uint<BITS, LIMBS>) {
+    let t0 = f.mul(a.0, b.0);
+    let t1 = f.mul(a.1, b.1);
+    let t2 = f.mul(f.add(a.0, a.1), f.add(b.0, b.1));
+    (f.sub(t0, t1), f.sub(f.sub(t2, t0), t1))
+}
+
+/// 16 double-and-add iterations: the repeating unit of scalar multiplication,
+/// with the real data-dependent branch on scalar bits.
+fn scalar_mul_segment<const BITS: usize, const LIMBS: usize>(
+    f: &Fq<BITS, LIMBS>,
+    mut acc: Jac<BITS, LIMBS>,
+    q: Jac<BITS, LIMBS>,
+    k: u16,
+) -> Jac<BITS, LIMBS> {
+    for i in (0..16).rev() {
+        acc = jac_double(f, acc);
+        if (k >> i) & 1 == 1 {
+            acc = jac_add(f, acc, q);
+        }
+    }
+    acc
+}
+
+/// Batch inversion via Montgomery's trick: N−1 prefix muls, one inv, 2(N−1)
+/// muls back. All values in Montgomery form.
+fn batch_inverse<const BITS: usize, const LIMBS: usize, const N: usize>(
+    f: &Fq<BITS, LIMBS>,
+    xs: [Uint<BITS, LIMBS>; N],
+) -> [Uint<BITS, LIMBS>; N] {
+    let mut prefix = [Uint::ZERO; N];
+    let mut acc = f.r1;
+    for i in 0..N {
+        prefix[i] = acc;
+        acc = f.mul(acc, xs[i]);
+    }
+    let mut inv_acc = f.inv(acc);
+    let mut out = [Uint::ZERO; N];
+    for i in (0..N).rev() {
+        out[i] = f.mul(inv_acc, prefix[i]);
+        inv_acc = f.mul(inv_acc, xs[i]);
+    }
+    out
+}
+
 /// Montgomery-form Jacobian point back to plain affine coordinates.
 fn to_affine<const BITS: usize, const LIMBS: usize>(
     f: &Fq<BITS, LIMBS>,
@@ -102,6 +152,38 @@ fn sanity_checks() {
     assert_eq!(to_affine(&f, g2), (G2_X, G2_Y), "jac_double: 2G mismatch");
     let g3 = jac_add(&f, g2, g);
     assert_eq!(to_affine(&f, g3), (G3_X, G3_Y), "jac_add: 3G mismatch");
+
+    // Scalar segment with k = 0 must equal 16 straight doublings.
+    let mut d16 = g;
+    for _ in 0..16 {
+        d16 = jac_double(&f, d16);
+    }
+    let seg = scalar_mul_segment(&f, g, g, 0);
+    assert_eq!(to_affine(&f, seg), to_affine(&f, d16), "scalar_mul_segment: k=0");
+
+    // Fp2: (a0 + a1·u)(a0 − a1·u) = a0² + a1², and u·u = −1.
+    let f2 = check_field("bls12_381_p", BLS12_381_P);
+    let (a0, a1) = (f2.to_mont(Uint::from(1234u64)), f2.to_mont(Uint::from(5678u64)));
+    let conj = fp2_mul(&f2, (a0, a1), (a0, f2.sub(Uint::ZERO, a1)));
+    assert_eq!(conj, (f2.add(f2.sqr(a0), f2.sqr(a1)), Uint::ZERO), "fp2_mul: conjugate");
+    let u = (Uint::ZERO, f2.r1);
+    assert_eq!(
+        fp2_mul(&f2, u, u),
+        (f2.to_mont(f2.p.wrapping_sub(Uint::ONE)), Uint::ZERO),
+        "fp2_mul: u^2 != -1"
+    );
+
+    // Batch inversion: xᵢ · out[i] == 1 (Montgomery form) for all i.
+    let xs = [
+        f2.to_mont(Uint::from(2u64)),
+        f2.to_mont(Uint::from(3u64)),
+        f2.to_mont(Uint::from(65537u64)),
+        a1,
+    ];
+    let inv = batch_inverse(&f2, xs);
+    for i in 0..xs.len() {
+        assert_eq!(f2.mul(xs[i], inv[i]), f2.r1, "batch_inverse[{i}]");
+    }
 }
 
 fn jac_point_strategy<const BITS: usize, const LIMBS: usize>(
@@ -136,4 +218,70 @@ pub fn group(criterion: &mut Criterion) {
     sanity_checks();
     bench_curve(criterion, "secp256k1", SECP256K1_P);
     bench_curve(criterion, "bls12_381_g1", BLS12_381_P);
+
+    // Fp2 multiplication (BLS12-381).
+    let f381 = Fq::new(BLS12_381_P);
+    let fp2_el = move || {
+        <(U384, U384)>::arbitrary()
+            .prop_map(move |(a, b)| (a.reduce_mod(BLS12_381_P), b.reduce_mod(BLS12_381_P)))
+    };
+    bench_arbitrary_with(
+        criterion,
+        "curves/bls12_381/fp2_mul",
+        (fp2_el(), fp2_el()),
+        move |(a, b)| fp2_mul(&f381, a, b),
+    );
+
+    // Scalar-mul segment (secp256k1): 16 doubles + data-dependent adds.
+    let f = Fq::new(SECP256K1_P);
+    bench_arbitrary_with(
+        criterion,
+        "curves/secp256k1/scalar_mul_segment16",
+        (jac_point_strategy(SECP256K1_P), jac_point_strategy(SECP256K1_P), u16::arbitrary()),
+        move |(acc, q, k)| scalar_mul_segment(&f, acc, q, k),
+    );
+
+    // ECDSA verify scalar prologue: w = s⁻¹ mod n; u1 = z·w; u2 = r·w.
+    let n = SECP256K1_N;
+    let scalar = move || {
+        U256::arbitrary().prop_map(move |x| {
+            let x = x.reduce_mod(n);
+            if x.is_zero() {
+                U256::ONE
+            } else {
+                x
+            }
+        })
+    };
+    bench_arbitrary_with(
+        criterion,
+        "curves/secp256k1/ecdsa_verify_prologue",
+        (scalar(), scalar(), scalar()),
+        move |(z, r, s)| {
+            let w = s.inv_mod(n).unwrap();
+            (z.mul_mod(w, n), r.mul_mod(w, n))
+        },
+    );
+
+    // Batch inversion of 64 elements (Montgomery's trick).
+    let nonzero = move || {
+        U256::arbitrary().prop_map(move |x| {
+            let x = x.reduce_mod(SECP256K1_P);
+            if x.is_zero() {
+                U256::ONE
+            } else {
+                x
+            }
+        })
+    };
+    bench_arbitrary_with(
+        criterion,
+        "curves/secp256k1/batch_inverse64",
+        proptest::collection::vec(nonzero(), 64).prop_map(|v| {
+            let mut arr = [U256::ZERO; 64];
+            arr.copy_from_slice(&v);
+            arr
+        }),
+        move |xs| batch_inverse(&f, xs),
+    );
 }

--- a/benches/benches/distributions.rs
+++ b/benches/benches/distributions.rs
@@ -38,6 +38,33 @@ pub fn group(criterion: &mut Criterion) {
         |(a, b)| a == b,
     );
 
+    // const_eq over the same distributions: guards the const-compatible
+    // formulation against distribution-sensitive regressions.
+    bench_arbitrary_with(
+        criterion,
+        "dist/const_eq/equal/256",
+        U256::arbitrary().prop_map(|x| (x, x)),
+        |(a, b)| a.const_eq(&b),
+    );
+    bench_arbitrary_with(
+        criterion,
+        "dist/const_eq/differ_low/256",
+        U256::arbitrary().prop_map(|x| (x, x ^ U256::ONE)),
+        |(a, b)| a.const_eq(&b),
+    );
+    bench_arbitrary_with(
+        criterion,
+        "dist/const_eq/differ_high/256",
+        U256::arbitrary().prop_map(|x| (x, x ^ (U256::ONE << 255))),
+        |(a, b)| a.const_eq(&b),
+    );
+    bench_arbitrary_with(
+        criterion,
+        "dist/const_eq/mixed50/256",
+        <(U256, bool)>::arbitrary().prop_map(|(x, e)| if e { (x, x) } else { (x, x ^ U256::ONE) }),
+        |(a, b)| a.const_eq(&b),
+    );
+
     // is_zero: mostly-nonzero stream with 10% zeros (flag-checking pattern).
     bench_arbitrary_with(
         criterion,

--- a/benches/benches/distributions.rs
+++ b/benches/benches/distributions.rs
@@ -1,0 +1,89 @@
+//! Comparison benchmarks with *realistic* input distributions. The existing
+//! `cmp` group uses uniform-random inputs, where `eq` is decided in the first
+//! limb ~100% of the time and every branch is perfectly predictable. Real
+//! 256-bit words are skewed: small counters, 160-bit addresses, hashes, and
+//! equality checks that are usually true or differ late. Branchy and
+//! branchless implementations rank differently across these distributions —
+//! wall-clock only; CodSpeed's simulator does not model prediction.
+
+use super::fields::U256;
+use crate::prelude::*;
+use proptest::{prop_oneof, strategy::Just};
+
+pub fn group(criterion: &mut Criterion) {
+    // eq: outcome and differing-limb position.
+    bench_arbitrary_with(
+        criterion,
+        "dist/eq/equal/256",
+        U256::arbitrary().prop_map(|x| (x, x)),
+        |(a, b)| a == b,
+    );
+    bench_arbitrary_with(
+        criterion,
+        "dist/eq/differ_low/256",
+        U256::arbitrary().prop_map(|x| (x, x ^ U256::ONE)),
+        |(a, b)| a == b,
+    );
+    bench_arbitrary_with(
+        criterion,
+        "dist/eq/differ_high/256",
+        U256::arbitrary().prop_map(|x| (x, x ^ (U256::ONE << 255))),
+        |(a, b)| a == b,
+    );
+    // 50/50 equal: hostile to branch prediction, friendly to branchless.
+    bench_arbitrary_with(
+        criterion,
+        "dist/eq/mixed50/256",
+        <(U256, bool)>::arbitrary().prop_map(|(x, e)| if e { (x, x) } else { (x, x ^ U256::ONE) }),
+        |(a, b)| a == b,
+    );
+
+    // is_zero: mostly-nonzero stream with 10% zeros (flag-checking pattern).
+    bench_arbitrary_with(
+        criterion,
+        "dist/is_zero/mixed10/256",
+        prop_oneof![
+            9 => U256::arbitrary().prop_map(|x| x | U256::ONE),
+            1 => Just(U256::ZERO),
+        ],
+        |a| a.is_zero(),
+    );
+
+    // lt: magnitude distributions.
+    let small = || <(u64, u64)>::arbitrary().prop_map(|(a, b)| (U256::from(a), U256::from(b)));
+    bench_arbitrary_with(criterion, "dist/lt/small64/256", small(), |(a, b)| a < b);
+    let addr_mask: U256 = (U256::ONE << 160) - U256::ONE;
+    bench_arbitrary_with(
+        criterion,
+        "dist/lt/address160/256",
+        <(U256, U256)>::arbitrary().prop_map(move |(a, b)| (a & addr_mask, b & addr_mask)),
+        |(a, b)| a < b,
+    );
+    bench_arbitrary_with(
+        criterion,
+        "dist/lt/mixed_magnitude/256",
+        <(u64, U256)>::arbitrary().prop_map(|(a, b)| (U256::from(a), b)),
+        |(a, b)| a < b,
+    );
+
+    // lt feeding divergent arms: comparison result steers real work.
+    bench_arbitrary_with(criterion, "dist/lt_arms/small64/256", small(), |(a, b)| {
+        if a < b {
+            a.wrapping_add(b)
+        } else {
+            a.wrapping_sub(b)
+        }
+    });
+    bench_arbitrary_with(
+        criterion,
+        "dist/lt_arms/random/256",
+        <(U256, U256)>::arbitrary(),
+        |(a, b)| {
+            if a < b {
+                a.wrapping_add(b)
+            } else {
+                a.wrapping_sub(b)
+            }
+        },
+    );
+}

--- a/benches/benches/fields.rs
+++ b/benches/benches/fields.rs
@@ -1,0 +1,139 @@
+//! Field-arithmetic kernels over the fixed moduli that dominate real-world
+//! ruint usage: secp256k1 (k256 ECDSA, both the base field and the scalar
+//! order), NIST P-256, BN254, BLS12-381, BLS12-377, and CSIDH-512 as the
+//! post-quantum representative.
+//!
+//! Unlike the generic `modular` group (random moduli), these benches use the
+//! actual primes, real fixed exponents (Fermat inversion, sqrt for point
+//! decompression, 65537), and Montgomery-domain kernels (`mul_redc`,
+//! `square_redc`) — the true inner loops of signature and pairing libraries.
+
+use crate::prelude::*;
+use ruint::aliases::U64;
+
+pub(crate) type U256 = Uint<256, 4>;
+pub(crate) type U384 = Uint<384, 6>;
+pub(crate) type U512 = Uint<512, 8>;
+
+// Moduli verified against their generating formulas:
+// secp256k1 p = 2^256 − 2^32 − 977; P-256 p = 2^256 − 2^224 + 2^192 + 2^96 − 1;
+// BN254 from t = 4965661367192848881; BLS12-381 from z = −0xd201000000010000;
+// BLS12-377 from z = 0x8508c00000000001;
+// CSIDH-512 p = 4·(∏ first 73 odd primes)·587 − 1.
+pub(crate) const SECP256K1_P: U256 =
+    uint!(0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f_U256);
+pub(crate) const SECP256K1_N: U256 =
+    uint!(0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141_U256);
+pub(crate) const P256_P: U256 =
+    uint!(0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff_U256);
+pub(crate) const P256_N: U256 =
+    uint!(0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551_U256);
+pub(crate) const BN254_P: U256 =
+    uint!(0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47_U256);
+pub(crate) const BN254_R: U256 =
+    uint!(0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001_U256);
+pub(crate) const BLS12_381_P: U384 =
+    uint!(0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab_U384);
+pub(crate) const BLS12_381_R: U256 =
+    uint!(0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001_U256);
+pub(crate) const BLS12_377_P: U384 =
+    uint!(0x1ae3a4617c510eac63b05c06ca1493b1a22d9f300f5138f1ef3622fba094800170b5d44300000008508c00000000001_U384);
+pub(crate) const BLS12_377_R: U256 =
+    uint!(0x12ab655e9a2ca55660b44d1e5c37b00159aa76fed00000010a11800000000001_U256);
+pub(crate) const CSIDH512_P: U512 =
+    uint!(0x65b48e8f740f89bffc8ab0d15e3e4c4ab42d083aedc88c425afbfcc69322c9cda7aac6c567f35507516730cc1f0b4f25c2721bf457aca8351b81b90533c6c87b_U512);
+
+/// Montgomery context for a fixed odd prime modulus.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Fq<const BITS: usize, const LIMBS: usize> {
+    pub p: Uint<BITS, LIMBS>,
+    pub inv: u64,
+    /// R mod p, i.e. the Montgomery form of 1.
+    pub r1: Uint<BITS, LIMBS>,
+    /// R² mod p.
+    pub r2: Uint<BITS, LIMBS>,
+}
+
+impl<const BITS: usize, const LIMBS: usize> Fq<BITS, LIMBS> {
+    pub fn new(p: Uint<BITS, LIMBS>) -> Self {
+        let inv: u64 = U64::wrapping_from(p).inv_ring().unwrap().wrapping_neg().to();
+        // R mod p = (2^BITS − 1 mod p) + 1; never wraps to 0 since p ∤ 2^BITS.
+        let r1 = (Uint::MAX % p).wrapping_add(Uint::ONE);
+        let r2 = r1.mul_mod(r1, p);
+        Self { p, inv, r1, r2 }
+    }
+
+    pub fn mul(&self, a: Uint<BITS, LIMBS>, b: Uint<BITS, LIMBS>) -> Uint<BITS, LIMBS> {
+        a.mul_redc(b, self.p, self.inv)
+    }
+
+    pub fn sqr(&self, a: Uint<BITS, LIMBS>) -> Uint<BITS, LIMBS> {
+        a.square_redc(self.p, self.inv)
+    }
+
+    pub fn add(&self, a: Uint<BITS, LIMBS>, b: Uint<BITS, LIMBS>) -> Uint<BITS, LIMBS> {
+        a.add_mod(b, self.p)
+    }
+
+    pub fn sub(&self, a: Uint<BITS, LIMBS>, b: Uint<BITS, LIMBS>) -> Uint<BITS, LIMBS> {
+        // a − b mod p for a, b < p: the wrap of `wrapping_sub` and the +p cancel.
+        let d = a.wrapping_sub(b);
+        if a < b {
+            d.wrapping_add(self.p)
+        } else {
+            d
+        }
+    }
+
+    pub fn to_mont(&self, a: Uint<BITS, LIMBS>) -> Uint<BITS, LIMBS> {
+        self.mul(a, self.r2)
+    }
+
+    pub fn from_mont(&self, a: Uint<BITS, LIMBS>) -> Uint<BITS, LIMBS> {
+        self.mul(a, Uint::ONE)
+    }
+
+    /// Montgomery-domain inverse: maps xR to x⁻¹R.
+    pub fn inv(&self, a: Uint<BITS, LIMBS>) -> Uint<BITS, LIMBS> {
+        // inv_mod(xR) = x⁻¹R⁻¹; two redc-muls by R² append the two missing Rs.
+        let i = a.inv_mod(self.p).unwrap();
+        self.mul(self.mul(i, self.r2), self.r2)
+    }
+}
+
+/// Build the context and verify it: wrong constants panic here instead of
+/// silently benchmarking garbage.
+pub(crate) fn check_field<const BITS: usize, const LIMBS: usize>(
+    name: &str,
+    p: Uint<BITS, LIMBS>,
+) -> Fq<BITS, LIMBS> {
+    assert!(p.bit(0), "{name}: modulus must be odd");
+    let f = Fq::new(p);
+    assert_eq!(f.inv.wrapping_mul(p.as_limbs()[0]), u64::MAX, "{name}: bad Montgomery inv");
+    let a = p.wrapping_sub(Uint::from(5u64));
+    let b = (p >> 1usize).wrapping_add(Uint::from(7u64));
+    assert_eq!(f.from_mont(f.to_mont(a)), a, "{name}: Montgomery round-trip");
+    assert_eq!(
+        f.mul(f.to_mont(a), f.to_mont(b)),
+        f.to_mont(a.mul_mod(b, p)),
+        "{name}: mul_redc disagrees with mul_mod"
+    );
+    assert_eq!(f.sqr(f.to_mont(a)), f.mul(f.to_mont(a), f.to_mont(a)), "{name}: square_redc");
+    assert_eq!(f.mul(f.inv(f.to_mont(b)), f.to_mont(b)), f.r1, "{name}: Montgomery inverse");
+    f
+}
+
+pub fn group(criterion: &mut Criterion) {
+    let _ = criterion;
+    check_field("secp256k1_p", SECP256K1_P);
+    check_field("secp256k1_n", SECP256K1_N);
+    check_field("p256_p", P256_P);
+    check_field("p256_n", P256_N);
+    check_field("bn254_p", BN254_P);
+    check_field("bn254_r", BN254_R);
+    check_field("bls12_381_p", BLS12_381_P);
+    check_field("bls12_381_r", BLS12_381_R);
+    check_field("bls12_377_p", BLS12_377_P);
+    check_field("bls12_377_r", BLS12_377_R);
+    check_field("csidh512_p", CSIDH512_P);
+}

--- a/benches/benches/fields.rs
+++ b/benches/benches/fields.rs
@@ -46,17 +46,24 @@ pub(crate) const CSIDH512_P: U512 =
 /// Montgomery context for a fixed odd prime modulus.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct Fq<const BITS: usize, const LIMBS: usize> {
-    pub p: Uint<BITS, LIMBS>,
+    pub p:   Uint<BITS, LIMBS>,
     pub inv: u64,
     /// R mod p, i.e. the Montgomery form of 1.
-    pub r1: Uint<BITS, LIMBS>,
+    pub r1:  Uint<BITS, LIMBS>,
     /// R² mod p.
-    pub r2: Uint<BITS, LIMBS>,
+    pub r2:  Uint<BITS, LIMBS>,
 }
 
+// `to_mont`/`from_mont` are domain conversions on the *argument*; the
+// receiver is the field context, so the self-convention lint does not apply.
+#[allow(clippy::wrong_self_convention)]
 impl<const BITS: usize, const LIMBS: usize> Fq<BITS, LIMBS> {
     pub fn new(p: Uint<BITS, LIMBS>) -> Self {
-        let inv: u64 = U64::wrapping_from(p).inv_ring().unwrap().wrapping_neg().to();
+        let inv: u64 = U64::wrapping_from(p)
+            .inv_ring()
+            .unwrap()
+            .wrapping_neg()
+            .to();
         // R mod p = (2^BITS − 1 mod p) + 1; never wraps to 0 since p ∤ 2^BITS.
         let r1 = (Uint::MAX % p).wrapping_add(Uint::ONE);
         let r2 = r1.mul_mod(r1, p);
@@ -78,11 +85,7 @@ impl<const BITS: usize, const LIMBS: usize> Fq<BITS, LIMBS> {
     pub fn sub(&self, a: Uint<BITS, LIMBS>, b: Uint<BITS, LIMBS>) -> Uint<BITS, LIMBS> {
         // a − b mod p for a, b < p: the wrap of `wrapping_sub` and the +p cancel.
         let d = a.wrapping_sub(b);
-        if a < b {
-            d.wrapping_add(self.p)
-        } else {
-            d
-        }
+        if a < b { d.wrapping_add(self.p) } else { d }
     }
 
     pub fn to_mont(&self, a: Uint<BITS, LIMBS>) -> Uint<BITS, LIMBS> {
@@ -109,17 +112,33 @@ pub(crate) fn check_field<const BITS: usize, const LIMBS: usize>(
 ) -> Fq<BITS, LIMBS> {
     assert!(p.bit(0), "{name}: modulus must be odd");
     let f = Fq::new(p);
-    assert_eq!(f.inv.wrapping_mul(p.as_limbs()[0]), u64::MAX, "{name}: bad Montgomery inv");
+    assert_eq!(
+        f.inv.wrapping_mul(p.as_limbs()[0]),
+        u64::MAX,
+        "{name}: bad Montgomery inv"
+    );
     let a = p.wrapping_sub(Uint::from(5u64));
     let b = (p >> 1usize).wrapping_add(Uint::from(7u64));
-    assert_eq!(f.from_mont(f.to_mont(a)), a, "{name}: Montgomery round-trip");
+    assert_eq!(
+        f.from_mont(f.to_mont(a)),
+        a,
+        "{name}: Montgomery round-trip"
+    );
     assert_eq!(
         f.mul(f.to_mont(a), f.to_mont(b)),
         f.to_mont(a.mul_mod(b, p)),
         "{name}: mul_redc disagrees with mul_mod"
     );
-    assert_eq!(f.sqr(f.to_mont(a)), f.mul(f.to_mont(a), f.to_mont(a)), "{name}: square_redc");
-    assert_eq!(f.mul(f.inv(f.to_mont(b)), f.to_mont(b)), f.r1, "{name}: Montgomery inverse");
+    assert_eq!(
+        f.sqr(f.to_mont(a)),
+        f.mul(f.to_mont(a), f.to_mont(a)),
+        "{name}: square_redc"
+    );
+    assert_eq!(
+        f.mul(f.inv(f.to_mont(b)), f.to_mont(b)),
+        f.r1,
+        "{name}: Montgomery inverse"
+    );
     f
 }
 
@@ -133,18 +152,30 @@ fn bench_field<const BITS: usize, const LIMBS: usize>(
     let reduced = move || Uint::<BITS, LIMBS>::arbitrary().prop_map(move |x| x.reduce_mod(p));
     let pair = move || (reduced(), reduced());
 
-    bench_arbitrary_with(criterion, &format!("fields/{name}/mul_redc"), pair(), move |(a, b)| {
-        f.mul(a, b)
-    });
-    bench_arbitrary_with(criterion, &format!("fields/{name}/square_redc"), reduced(), move |a| {
-        f.sqr(a)
-    });
-    bench_arbitrary_with(criterion, &format!("fields/{name}/add_mod"), pair(), move |(a, b)| {
-        a.add_mod(b, p)
-    });
-    bench_arbitrary_with(criterion, &format!("fields/{name}/inv_mod"), reduced(), move |a| {
-        a.inv_mod(p)
-    });
+    bench_arbitrary_with(
+        criterion,
+        &format!("fields/{name}/mul_redc"),
+        pair(),
+        move |(a, b)| f.mul(a, b),
+    );
+    bench_arbitrary_with(
+        criterion,
+        &format!("fields/{name}/square_redc"),
+        reduced(),
+        move |a| f.sqr(a),
+    );
+    bench_arbitrary_with(
+        criterion,
+        &format!("fields/{name}/add_mod"),
+        pair(),
+        move |(a, b)| a.add_mod(b, p),
+    );
+    bench_arbitrary_with(
+        criterion,
+        &format!("fields/{name}/inv_mod"),
+        reduced(),
+        move |a| a.inv_mod(p),
+    );
     // Real fixed exponents: Fermat inversion a^(p−2), point-decompression sqrt
     // a^((p+1)/4) (p ≡ 3 mod 4 only), and the RSA verify exponent 65537.
     let fermat = p.wrapping_sub(Uint::from(2u64));

--- a/benches/benches/fields.rs
+++ b/benches/benches/fields.rs
@@ -123,17 +123,65 @@ pub(crate) fn check_field<const BITS: usize, const LIMBS: usize>(
     f
 }
 
+fn bench_field<const BITS: usize, const LIMBS: usize>(
+    criterion: &mut Criterion,
+    name: &str,
+    p: Uint<BITS, LIMBS>,
+    sqrt: bool,
+) {
+    let f = check_field(name, p);
+    let reduced = move || Uint::<BITS, LIMBS>::arbitrary().prop_map(move |x| x.reduce_mod(p));
+    let pair = move || (reduced(), reduced());
+
+    bench_arbitrary_with(criterion, &format!("fields/{name}/mul_redc"), pair(), move |(a, b)| {
+        f.mul(a, b)
+    });
+    bench_arbitrary_with(criterion, &format!("fields/{name}/square_redc"), reduced(), move |a| {
+        f.sqr(a)
+    });
+    bench_arbitrary_with(criterion, &format!("fields/{name}/add_mod"), pair(), move |(a, b)| {
+        a.add_mod(b, p)
+    });
+    bench_arbitrary_with(criterion, &format!("fields/{name}/inv_mod"), reduced(), move |a| {
+        a.inv_mod(p)
+    });
+    // Real fixed exponents: Fermat inversion a^(p−2), point-decompression sqrt
+    // a^((p+1)/4) (p ≡ 3 mod 4 only), and the RSA verify exponent 65537.
+    let fermat = p.wrapping_sub(Uint::from(2u64));
+    bench_arbitrary_with(
+        criterion,
+        &format!("fields/{name}/pow_mod/fermat"),
+        reduced(),
+        move |a| a.pow_mod(fermat, p),
+    );
+    if sqrt {
+        let e = (p >> 2usize).wrapping_add(Uint::ONE);
+        bench_arbitrary_with(
+            criterion,
+            &format!("fields/{name}/pow_mod/sqrt"),
+            reduced(),
+            move |a| a.pow_mod(e, p),
+        );
+    }
+    bench_arbitrary_with(
+        criterion,
+        &format!("fields/{name}/pow_mod/e65537"),
+        reduced(),
+        move |a| a.pow_mod(Uint::from(65537u64), p),
+    );
+}
+
 pub fn group(criterion: &mut Criterion) {
-    let _ = criterion;
-    check_field("secp256k1_p", SECP256K1_P);
-    check_field("secp256k1_n", SECP256K1_N);
-    check_field("p256_p", P256_P);
-    check_field("p256_n", P256_N);
-    check_field("bn254_p", BN254_P);
-    check_field("bn254_r", BN254_R);
-    check_field("bls12_381_p", BLS12_381_P);
-    check_field("bls12_381_r", BLS12_381_R);
-    check_field("bls12_377_p", BLS12_377_P);
-    check_field("bls12_377_r", BLS12_377_R);
-    check_field("csidh512_p", CSIDH512_P);
+    bench_field(criterion, "secp256k1_p", SECP256K1_P, true);
+    bench_field(criterion, "secp256k1_n", SECP256K1_N, false);
+    bench_field(criterion, "p256_p", P256_P, true);
+    bench_field(criterion, "p256_n", P256_N, false);
+    bench_field(criterion, "bn254_p", BN254_P, true);
+    bench_field(criterion, "bn254_r", BN254_R, false);
+    bench_field(criterion, "bls12_381_p", BLS12_381_P, true);
+    bench_field(criterion, "bls12_381_r", BLS12_381_R, false);
+    // BLS12-377 p ≡ 1 (mod 4): the (p+1)/4 sqrt exponent does not apply.
+    bench_field(criterion, "bls12_377_p", BLS12_377_P, false);
+    bench_field(criterion, "bls12_377_r", BLS12_377_R, false);
+    bench_field(criterion, "csidh512_p", CSIDH512_P, true);
 }

--- a/benches/benches/latency.rs
+++ b/benches/benches/latency.rs
@@ -1,0 +1,102 @@
+//! Latency-chain benchmarks: each measurement is `CHAIN` applications of an
+//! op where the output feeds the next input, so the CPU cannot overlap
+//! iterations. This measures the *critical-path latency* of an op — the cost
+//! that matters when its result feeds control or data flow (pow_mod ladders,
+//! comparison-then-branch) — which throughput-style benches and CodSpeed's
+//! instruction counting are both blind to.
+//!
+//! Reported time ≈ CHAIN × per-op latency; divide by `CHAIN` (64).
+
+use super::fields::{Fq, BLS12_381_P, SECP256K1_P, U256};
+use crate::prelude::*;
+
+const CHAIN: usize = 64;
+
+pub fn group(criterion: &mut Criterion) {
+    // Plain wrapping ops. black_box pins the intermediate so the loop cannot
+    // be reassociated or folded; it adds ~1 register move per link.
+    bench_arbitrary_with(criterion, "chained/mul/256", <(U256, U256)>::arbitrary(), |(mut x, y)| {
+        let y = y | U256::ONE;
+        for _ in 0..CHAIN {
+            x = black_box(x.wrapping_mul(y));
+        }
+        x
+    });
+    bench_arbitrary_with(criterion, "chained/add/256", <(U256, U256)>::arbitrary(), |(mut x, y)| {
+        for _ in 0..CHAIN {
+            x = black_box(x.wrapping_add(y));
+        }
+        x
+    });
+
+    // Comparison ops: the boolean result feeds the next value, modeling
+    // compare-then-act code. The +1/+2 depends on the comparison, so the
+    // dependency is enforced without black_box.
+    bench_arbitrary_with(criterion, "chained/eq/256", <(U256, U256)>::arbitrary(), |(mut x, y)| {
+        for _ in 0..CHAIN {
+            let e = (x == y) as u64;
+            x = x.wrapping_add(U256::from(e + 1));
+        }
+        x
+    });
+    bench_arbitrary_with(criterion, "chained/is_zero/256", U256::arbitrary(), |mut x| {
+        for _ in 0..CHAIN {
+            let z = x.is_zero() as u64;
+            x = x.wrapping_add(U256::from(z + 1));
+        }
+        x
+    });
+
+    // Montgomery kernels: x = f(x, y) is exactly the pow_mod inner loop.
+    chained_redc(criterion, "secp256k1_p", SECP256K1_P);
+    chained_redc(criterion, "bls12_381_p", BLS12_381_P);
+
+    let p = SECP256K1_P;
+    bench_arbitrary_with(
+        criterion,
+        "chained/add_mod/secp256k1_p",
+        (reduced(p), reduced(p)),
+        move |(mut x, y)| {
+            for _ in 0..CHAIN {
+                x = x.add_mod(y, p);
+            }
+            x
+        },
+    );
+}
+
+fn reduced<const BITS: usize, const LIMBS: usize>(
+    p: Uint<BITS, LIMBS>,
+) -> impl Strategy<Value = Uint<BITS, LIMBS>> {
+    Uint::arbitrary().prop_map(move |x| x.reduce_mod(p))
+}
+
+fn chained_redc<const BITS: usize, const LIMBS: usize>(
+    criterion: &mut Criterion,
+    name: &str,
+    p: Uint<BITS, LIMBS>,
+) {
+    let f = Fq::new(p);
+    bench_arbitrary_with(
+        criterion,
+        &format!("chained/mul_redc/{name}"),
+        (reduced(p), reduced(p)),
+        move |(mut x, y)| {
+            for _ in 0..CHAIN {
+                x = f.mul(x, y);
+            }
+            x
+        },
+    );
+    bench_arbitrary_with(
+        criterion,
+        &format!("chained/square_redc/{name}"),
+        reduced(p),
+        move |mut x| {
+            for _ in 0..CHAIN {
+                x = f.sqr(x);
+            }
+            x
+        },
+    );
+}

--- a/benches/benches/latency.rs
+++ b/benches/benches/latency.rs
@@ -42,30 +42,8 @@ pub fn group(criterion: &mut Criterion) {
     // Comparison ops: the boolean result feeds the next value, modeling
     // compare-then-act code. The +1/+2 depends on the comparison, so the
     // dependency is enforced without black_box.
-    bench_arbitrary_with(
-        criterion,
-        "chained/eq/256",
-        <(U256, U256)>::arbitrary(),
-        |(mut x, y)| {
-            for _ in 0..CHAIN {
-                let e = (x == y) as u64;
-                x = x.wrapping_add(U256::from(e + 1));
-            }
-            x
-        },
-    );
-    bench_arbitrary_with(
-        criterion,
-        "chained/is_zero/256",
-        U256::arbitrary(),
-        |mut x| {
-            for _ in 0..CHAIN {
-                let z = x.is_zero() as u64;
-                x = x.wrapping_add(U256::from(z + 1));
-            }
-            x
-        },
-    );
+    chained_cmp::<256, 4>(criterion);
+    chained_cmp::<512, 8>(criterion);
 
     // Montgomery kernels: x = f(x, y) is exactly the pow_mod inner loop.
     chained_redc(criterion, "secp256k1_p", SECP256K1_P);
@@ -79,6 +57,58 @@ pub fn group(criterion: &mut Criterion) {
         move |(mut x, y)| {
             for _ in 0..CHAIN {
                 x = x.add_mod(y, p);
+            }
+            x
+        },
+    );
+}
+
+fn chained_cmp<const BITS: usize, const LIMBS: usize>(criterion: &mut Criterion) {
+    type U<const BITS: usize, const LIMBS: usize> = Uint<BITS, LIMBS>;
+    bench_arbitrary_with(
+        criterion,
+        &format!("chained/eq/{BITS}"),
+        <(U<BITS, LIMBS>, U<BITS, LIMBS>)>::arbitrary(),
+        |(mut x, y)| {
+            for _ in 0..CHAIN {
+                let e = (x == y) as u64;
+                x = x.wrapping_add(U::from(e + 1));
+            }
+            x
+        },
+    );
+    bench_arbitrary_with(
+        criterion,
+        &format!("chained/const_eq/{BITS}"),
+        <(U<BITS, LIMBS>, U<BITS, LIMBS>)>::arbitrary(),
+        |(mut x, y)| {
+            for _ in 0..CHAIN {
+                let e = x.const_eq(&y) as u64;
+                x = x.wrapping_add(U::from(e + 1));
+            }
+            x
+        },
+    );
+    bench_arbitrary_with(
+        criterion,
+        &format!("chained/is_zero/{BITS}"),
+        U::<BITS, LIMBS>::arbitrary(),
+        |mut x| {
+            for _ in 0..CHAIN {
+                let z = x.is_zero() as u64;
+                x = x.wrapping_add(U::from(z + 1));
+            }
+            x
+        },
+    );
+    bench_arbitrary_with(
+        criterion,
+        &format!("chained/const_is_zero/{BITS}"),
+        U::<BITS, LIMBS>::arbitrary(),
+        |mut x| {
+            for _ in 0..CHAIN {
+                let z = x.const_is_zero() as u64;
+                x = x.wrapping_add(U::from(z + 1));
             }
             x
         },

--- a/benches/benches/latency.rs
+++ b/benches/benches/latency.rs
@@ -7,7 +7,7 @@
 //!
 //! Reported time ≈ CHAIN × per-op latency; divide by `CHAIN` (64).
 
-use super::fields::{Fq, BLS12_381_P, SECP256K1_P, U256};
+use super::fields::{BLS12_381_P, Fq, SECP256K1_P, U256};
 use crate::prelude::*;
 
 const CHAIN: usize = 64;
@@ -15,37 +15,57 @@ const CHAIN: usize = 64;
 pub fn group(criterion: &mut Criterion) {
     // Plain wrapping ops. black_box pins the intermediate so the loop cannot
     // be reassociated or folded; it adds ~1 register move per link.
-    bench_arbitrary_with(criterion, "chained/mul/256", <(U256, U256)>::arbitrary(), |(mut x, y)| {
-        let y = y | U256::ONE;
-        for _ in 0..CHAIN {
-            x = black_box(x.wrapping_mul(y));
-        }
-        x
-    });
-    bench_arbitrary_with(criterion, "chained/add/256", <(U256, U256)>::arbitrary(), |(mut x, y)| {
-        for _ in 0..CHAIN {
-            x = black_box(x.wrapping_add(y));
-        }
-        x
-    });
+    bench_arbitrary_with(
+        criterion,
+        "chained/mul/256",
+        <(U256, U256)>::arbitrary(),
+        |(mut x, y)| {
+            let y = y | U256::ONE;
+            for _ in 0..CHAIN {
+                x = black_box(x.wrapping_mul(y));
+            }
+            x
+        },
+    );
+    bench_arbitrary_with(
+        criterion,
+        "chained/add/256",
+        <(U256, U256)>::arbitrary(),
+        |(mut x, y)| {
+            for _ in 0..CHAIN {
+                x = black_box(x.wrapping_add(y));
+            }
+            x
+        },
+    );
 
     // Comparison ops: the boolean result feeds the next value, modeling
     // compare-then-act code. The +1/+2 depends on the comparison, so the
     // dependency is enforced without black_box.
-    bench_arbitrary_with(criterion, "chained/eq/256", <(U256, U256)>::arbitrary(), |(mut x, y)| {
-        for _ in 0..CHAIN {
-            let e = (x == y) as u64;
-            x = x.wrapping_add(U256::from(e + 1));
-        }
-        x
-    });
-    bench_arbitrary_with(criterion, "chained/is_zero/256", U256::arbitrary(), |mut x| {
-        for _ in 0..CHAIN {
-            let z = x.is_zero() as u64;
-            x = x.wrapping_add(U256::from(z + 1));
-        }
-        x
-    });
+    bench_arbitrary_with(
+        criterion,
+        "chained/eq/256",
+        <(U256, U256)>::arbitrary(),
+        |(mut x, y)| {
+            for _ in 0..CHAIN {
+                let e = (x == y) as u64;
+                x = x.wrapping_add(U256::from(e + 1));
+            }
+            x
+        },
+    );
+    bench_arbitrary_with(
+        criterion,
+        "chained/is_zero/256",
+        U256::arbitrary(),
+        |mut x| {
+            for _ in 0..CHAIN {
+                let z = x.is_zero() as u64;
+                x = x.wrapping_add(U256::from(z + 1));
+            }
+            x
+        },
+    );
 
     // Montgomery kernels: x = f(x, y) is exactly the pow_mod inner loop.
     chained_redc(criterion, "secp256k1_p", SECP256K1_P);

--- a/benches/benches/mod.rs
+++ b/benches/benches/mod.rs
@@ -4,6 +4,7 @@ mod base_convert;
 mod bits;
 mod cmp;
 mod div;
+mod fields;
 mod fmt;
 mod from;
 mod log;
@@ -25,6 +26,7 @@ pub fn group(c: &mut criterion::Criterion) {
     log::group(c);
     root::group(c);
     modular::group(c);
+    fields::group(c);
 
     cmp::group(c);
 

--- a/benches/benches/mod.rs
+++ b/benches/benches/mod.rs
@@ -4,6 +4,7 @@ mod base_convert;
 mod bits;
 mod cmp;
 mod curves;
+mod distributions;
 mod div;
 mod fields;
 mod fmt;
@@ -33,6 +34,7 @@ pub fn group(c: &mut criterion::Criterion) {
     curves::group(c);
 
     cmp::group(c);
+    distributions::group(c);
 
     base_convert::group(c);
     from::group(c);

--- a/benches/benches/mod.rs
+++ b/benches/benches/mod.rs
@@ -3,6 +3,7 @@ mod algorithms;
 mod base_convert;
 mod bits;
 mod cmp;
+mod curves;
 mod div;
 mod fields;
 mod fmt;
@@ -29,6 +30,7 @@ pub fn group(c: &mut criterion::Criterion) {
     modular::group(c);
     fields::group(c);
     latency::group(c);
+    curves::group(c);
 
     cmp::group(c);
 

--- a/benches/benches/mod.rs
+++ b/benches/benches/mod.rs
@@ -7,6 +7,7 @@ mod div;
 mod fields;
 mod fmt;
 mod from;
+mod latency;
 mod log;
 mod modular;
 mod mul;
@@ -27,6 +28,7 @@ pub fn group(c: &mut criterion::Criterion) {
     root::group(c);
     modular::group(c);
     fields::group(c);
+    latency::group(c);
 
     cmp::group(c);
 

--- a/benches/benches/prelude.rs
+++ b/benches/benches/prelude.rs
@@ -130,6 +130,10 @@ fn manual_batch<T, U>(
 
 #[allow(dead_code)]
 fn get_batch_size(name: &str) -> usize {
+    // Chained and composite-kernel benches do 16-64 core ops per call; batch less.
+    if name.starts_with("chained/") || name.starts_with("curves/") {
+        return 100;
+    }
     let size = name.split('/').flat_map(str::parse::<usize>).max();
     if name.contains("pow") {
         if size >= Some(4096) { 1 } else { 100 }

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -137,13 +137,55 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         });
         equal_count == LIMBS
     }
+
+    /// Returns `true` if `self` equals `other`.
+    ///
+    /// Prototype reformulation of [`const_eq`](Self::const_eq) that compares
+    /// double-word (`u128`) chunks instead of counting equal limbs. LLVM
+    /// lowers this to the same code as the derived `PartialEq` (`==`), while
+    /// the limb-counting loop gets auto-vectorized into a horizontal
+    /// reduction with worse dependent-use latency.
+    #[inline]
+    #[must_use]
+    pub const fn const_eq_dw(&self, other: &Self) -> bool {
+        as_primitives!(self, other; {
+            u64(x, y) => return x == y,
+            u128(x, y) => return x == y,
+        });
+        let mut eq = true;
+        if LIMBS >= 2 {
+            let a = self.as_double_words();
+            let b = other.as_double_words();
+            const_range_for!(i in 0..LIMBS / 2 => {
+                eq &= a[i].get() == b[i].get();
+            });
+        }
+        if LIMBS % 2 == 1 {
+            eq &= self.limbs[LIMBS - 1] == other.limbs[LIMBS - 1];
+        }
+        eq
+    }
+
+    /// Returns `true` if the value is zero.
+    ///
+    /// Prototype reformulation of [`const_is_zero`](Self::const_is_zero) on
+    /// top of [`const_eq_dw`](Self::const_eq_dw).
+    #[inline]
+    #[must_use]
+    pub const fn const_is_zero_dw(&self) -> bool {
+        as_primitives!(self; {
+            u64(x) => return x == 0,
+            u128(x) => return x == 0,
+        });
+        self.const_eq_dw(&Self::ZERO)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{Uint, const_for, nlimbs};
     use core::cmp::Ordering;
-    use proptest::{prop_assert_eq, proptest};
+    use proptest::{prop_assert, prop_assert_eq, proptest};
 
     fn reference_cmp<const BITS: usize, const LIMBS: usize>(
         a: &Uint<BITS, LIMBS>,
@@ -192,6 +234,52 @@ mod tests {
             type U = Uint<BITS, LIMBS>;
             proptest!(|(a: U, b: U)| {
                 check_cmp(a, b)?;
+            });
+        });
+    }
+
+    #[test]
+    fn test_const_eq_dw_ctfe() {
+        const OK: bool = {
+            let a = Uint::<256, 4>::from_limbs([1, 2, 3, 4]);
+            let b = Uint::<256, 4>::from_limbs([1, 2, 3, 5]);
+            let c = Uint::<192, 3>::from_limbs([1, 2, 3]);
+            let d = Uint::<192, 3>::from_limbs([1, 2, 4]);
+            a.const_eq_dw(&a)
+                && !a.const_eq_dw(&b)
+                && !a.const_is_zero_dw()
+                && Uint::<256, 4>::ZERO.const_is_zero_dw()
+                && c.const_eq_dw(&c)
+                && !c.const_eq_dw(&d)
+        };
+        const { assert!(OK) };
+    }
+
+    #[test]
+    fn test_const_eq_dw() {
+        const_for!(BITS in SIZES {
+            const LIMBS: usize = nlimbs(BITS);
+            type U = Uint<BITS, LIMBS>;
+            assert!(U::ZERO.const_eq_dw(&U::ZERO));
+            assert!(U::ZERO.const_is_zero_dw());
+            assert!(U::MAX.const_eq_dw(&U::MAX));
+            assert_eq!(U::MAX.const_is_zero_dw(), U::MAX.is_zero());
+            proptest!(|(a: U, b: U)| {
+                prop_assert_eq!(a.const_eq_dw(&b), a == b);
+                prop_assert!(a.const_eq_dw(&a));
+                prop_assert_eq!(a.const_is_zero_dw(), a.is_zero());
+            });
+        });
+        // A difference in any single limb must be detected.
+        const_for!(BITS in NON_ZERO {
+            const LIMBS: usize = nlimbs(BITS);
+            type U = Uint<BITS, LIMBS>;
+            proptest!(|(a: U, limb in 0..LIMBS)| {
+                let mut b = a;
+                // Bit 0 of every limb is always within the mask.
+                unsafe { b.as_limbs_mut()[limb] ^= 1 };
+                prop_assert!(!a.const_eq_dw(&b));
+                prop_assert!(!b.const_eq_dw(&a));
             });
         });
     }

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -95,89 +95,88 @@ impl_for_primitives!(
     i8, i16, i32, i64, i128, isize,
 );
 
+/// `const_eq` compares double-word chunks up to this many limbs, and falls
+/// back to a limb-counting loop above it. The chunked form lowers to the same
+/// code as the derived `PartialEq` (flag chain on aarch64, `pxor`/`ptest` on
+/// x86-64), but its serial dependency chain loses to LLVM's auto-vectorization
+/// of the counting loop at high limb counts (measured cliff at 24 limbs on
+/// Zen 2, crossover by 64 limbs on Apple M-series).
+const EQ_DW_MAX_LIMBS: usize = 16;
+
 impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// Returns `true` if the value is zero.
     #[inline]
     #[must_use]
     pub fn is_zero(&self) -> bool {
-        *self == Self::ZERO
+        if LIMBS <= EQ_DW_MAX_LIMBS {
+            self.const_is_zero()
+        } else {
+            // Comparing against the constant `ZERO` lowers to `bcmp` against
+            // an all-zeros constant, which beats every const-compatible
+            // formulation at high limb counts but is not reachable from
+            // `const fn`.
+            *self == Self::ZERO
+        }
     }
 
     /// Returns `true` if the value is zero.
     ///
-    /// Note that this currently might perform worse than
-    /// [`is_zero`](Self::is_zero).
+    /// This is equivalent to [`is_zero`](Self::is_zero), usable in `const`
+    /// contexts. For more than 16 limbs (1024 bits) this may perform worse
+    /// than [`is_zero`](Self::is_zero), which can compare against the zero
+    /// constant with `memcmp`.
     #[inline]
     #[must_use]
     pub const fn const_is_zero(&self) -> bool {
-        as_primitives!(self; {
-            u64(x) => return x == 0,
-            u128(x) => return x == 0,
-        });
-        self.const_eq(&Self::ZERO)
+        if LIMBS <= EQ_DW_MAX_LIMBS {
+            self.const_eq(&Self::ZERO)
+        } else {
+            // An OR-fold auto-vectorizes into a plain vector reduction with
+            // no comparisons, which wins at high limb counts. Below the
+            // cutoff the same auto-vectorization costs a vector->scalar
+            // domain crossing that `const_eq`'s chunked form avoids.
+            let mut acc = 0u64;
+            const_range_for!(limb in ref self.as_limbs() => {
+                acc |= *limb;
+            });
+            acc == 0
+        }
     }
 
     /// Returns `true` if `self` equals `other`.
     ///
-    /// Note that this currently might perform worse than the derived
-    /// `PartialEq` (`==` operator).
+    /// This is equivalent to the derived `PartialEq` (`==` operator), usable
+    /// in `const` contexts.
     #[inline]
     #[must_use]
     pub const fn const_eq(&self, other: &Self) -> bool {
-        as_primitives!(self, other; {
-            u64(x, y) => return x == y,
-            u128(x, y) => return x == y,
-        });
         // TODO: Replace with `self == other` and deprecate once `PartialEq` is const.
-        let a = self.as_limbs();
-        let b = other.as_limbs();
-        let mut equal_count = 0usize;
-        const_range_for!(i in 0..LIMBS => {
-            equal_count += (a[i] == b[i]) as usize;
-        });
-        equal_count == LIMBS
-    }
-
-    /// Returns `true` if `self` equals `other`.
-    ///
-    /// Prototype reformulation of [`const_eq`](Self::const_eq) that compares
-    /// double-word (`u128`) chunks instead of counting equal limbs. LLVM
-    /// lowers this to the same code as the derived `PartialEq` (`==`), while
-    /// the limb-counting loop gets auto-vectorized into a horizontal
-    /// reduction with worse dependent-use latency.
-    #[inline]
-    #[must_use]
-    pub const fn const_eq_dw(&self, other: &Self) -> bool {
         as_primitives!(self, other; {
             u64(x, y) => return x == y,
             u128(x, y) => return x == y,
         });
-        let mut eq = true;
-        if LIMBS >= 2 {
-            let a = self.as_double_words();
-            let b = other.as_double_words();
-            const_range_for!(i in 0..LIMBS / 2 => {
-                eq &= a[i].get() == b[i].get();
+        if LIMBS <= EQ_DW_MAX_LIMBS {
+            let mut eq = true;
+            if LIMBS >= 2 {
+                let a = self.as_double_words();
+                let b = other.as_double_words();
+                const_range_for!(i in 0..LIMBS / 2 => {
+                    eq &= a[i].get() == b[i].get();
+                });
+            }
+            if LIMBS % 2 == 1 {
+                eq &= self.limbs[LIMBS - 1] == other.limbs[LIMBS - 1];
+            }
+            eq
+        } else {
+            let a = self.as_limbs();
+            let b = other.as_limbs();
+            let mut equal_count = 0usize;
+            const_range_for!(i in 0..LIMBS => {
+                equal_count += (a[i] == b[i]) as usize;
             });
+            equal_count == LIMBS
         }
-        if LIMBS % 2 == 1 {
-            eq &= self.limbs[LIMBS - 1] == other.limbs[LIMBS - 1];
-        }
-        eq
-    }
-
-    /// Returns `true` if the value is zero.
-    ///
-    /// Prototype reformulation of [`const_is_zero`](Self::const_is_zero) on
-    /// top of [`const_eq_dw`](Self::const_eq_dw).
-    #[inline]
-    #[must_use]
-    pub const fn const_is_zero_dw(&self) -> bool {
-        as_primitives!(self; {
-            u64(x) => return x == 0,
-            u128(x) => return x == 0,
-        });
-        self.const_eq_dw(&Self::ZERO)
     }
 }
 
@@ -239,35 +238,35 @@ mod tests {
     }
 
     #[test]
-    fn test_const_eq_dw_ctfe() {
+    fn test_const_eq_ctfe() {
         const OK: bool = {
             let a = Uint::<256, 4>::from_limbs([1, 2, 3, 4]);
             let b = Uint::<256, 4>::from_limbs([1, 2, 3, 5]);
             let c = Uint::<192, 3>::from_limbs([1, 2, 3]);
             let d = Uint::<192, 3>::from_limbs([1, 2, 4]);
-            a.const_eq_dw(&a)
-                && !a.const_eq_dw(&b)
-                && !a.const_is_zero_dw()
-                && Uint::<256, 4>::ZERO.const_is_zero_dw()
-                && c.const_eq_dw(&c)
-                && !c.const_eq_dw(&d)
+            a.const_eq(&a)
+                && !a.const_eq(&b)
+                && !a.const_is_zero()
+                && Uint::<256, 4>::ZERO.const_is_zero()
+                && c.const_eq(&c)
+                && !c.const_eq(&d)
         };
         const { assert!(OK) };
     }
 
     #[test]
-    fn test_const_eq_dw() {
+    fn test_const_eq() {
         const_for!(BITS in SIZES {
             const LIMBS: usize = nlimbs(BITS);
             type U = Uint<BITS, LIMBS>;
-            assert!(U::ZERO.const_eq_dw(&U::ZERO));
-            assert!(U::ZERO.const_is_zero_dw());
-            assert!(U::MAX.const_eq_dw(&U::MAX));
-            assert_eq!(U::MAX.const_is_zero_dw(), U::MAX.is_zero());
+            assert!(U::ZERO.const_eq(&U::ZERO));
+            assert!(U::ZERO.const_is_zero());
+            assert!(U::MAX.const_eq(&U::MAX));
+            assert_eq!(U::MAX.const_is_zero(), U::MAX.is_zero());
             proptest!(|(a: U, b: U)| {
-                prop_assert_eq!(a.const_eq_dw(&b), a == b);
-                prop_assert!(a.const_eq_dw(&a));
-                prop_assert_eq!(a.const_is_zero_dw(), a.is_zero());
+                prop_assert_eq!(a.const_eq(&b), a == b);
+                prop_assert!(a.const_eq(&a));
+                prop_assert_eq!(a.const_is_zero(), a.is_zero());
             });
         });
         // A difference in any single limb must be detected.
@@ -278,8 +277,8 @@ mod tests {
                 let mut b = a;
                 // Bit 0 of every limb is always within the mask.
                 unsafe { b.as_limbs_mut()[limb] ^= 1 };
-                prop_assert!(!a.const_eq_dw(&b));
-                prop_assert!(!b.const_eq_dw(&a));
+                prop_assert!(!a.const_eq(&b));
+                prop_assert!(!b.const_eq(&a));
             });
         });
     }

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -95,20 +95,26 @@ impl_for_primitives!(
     i8, i16, i32, i64, i128, isize,
 );
 
-/// `const_eq` compares double-word chunks up to this many limbs, and falls
-/// back to a limb-counting loop above it. The chunked form lowers to the same
-/// code as the derived `PartialEq` (flag chain on aarch64, `pxor`/`ptest` on
-/// x86-64), but its serial dependency chain loses to LLVM's auto-vectorization
-/// of the counting loop at high limb counts (measured cliff at 24 limbs on
-/// Zen 2, crossover by 64 limbs on Apple M-series).
-const EQ_DW_MAX_LIMBS: usize = 16;
+/// `const_eq` XOR-folds the limbs up to this many limbs, and falls back to a
+/// limb-counting loop above it. LLVM lowers the fold by context: when the
+/// result feeds a dependency chain and the operands live in registers it
+/// stays scalar (`xor`/`or` on x86-64, `ccmp` flags on aarch64), avoiding
+/// the vector round-trip that stalls dependent use (measured 44% faster
+/// per link than the double-word form on Zen 2 at 256 bits); standalone it
+/// re-vectorizes at 8+ limbs (`pxor`/`ptest` on x86-64, NEON on aarch64).
+/// At 4 limbs x86-64 keeps even the standalone form scalar, costing ~0.3 ns
+/// against `ptest` but still beating the derived `PartialEq`. At high limb
+/// counts the serial forms lose to LLVM's auto-vectorization of the counting
+/// loop (measured cliff at 24 limbs on Zen 2, crossover by 64 limbs on Apple
+/// M-series).
+const EQ_FOLD_MAX_LIMBS: usize = 16;
 
 impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     /// Returns `true` if the value is zero.
     #[inline]
     #[must_use]
     pub fn is_zero(&self) -> bool {
-        if LIMBS <= EQ_DW_MAX_LIMBS {
+        if LIMBS <= EQ_FOLD_MAX_LIMBS {
             self.const_is_zero()
         } else {
             // Comparing against the constant `ZERO` lowers to `bcmp` against
@@ -128,7 +134,7 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     #[inline]
     #[must_use]
     pub const fn const_is_zero(&self) -> bool {
-        if LIMBS <= EQ_DW_MAX_LIMBS {
+        if LIMBS <= EQ_FOLD_MAX_LIMBS {
             self.const_eq(&Self::ZERO)
         } else {
             // An OR-fold auto-vectorizes into a plain vector reduction with
@@ -155,19 +161,14 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
             u64(x, y) => return x == y,
             u128(x, y) => return x == y,
         });
-        if LIMBS <= EQ_DW_MAX_LIMBS {
-            let mut eq = true;
-            if LIMBS >= 2 {
-                let a = self.as_double_words();
-                let b = other.as_double_words();
-                const_range_for!(i in 0..LIMBS / 2 => {
-                    eq &= a[i].get() == b[i].get();
-                });
-            }
-            if LIMBS % 2 == 1 {
-                eq &= self.limbs[LIMBS - 1] == other.limbs[LIMBS - 1];
-            }
-            eq
+        if LIMBS <= EQ_FOLD_MAX_LIMBS {
+            let a = self.as_limbs();
+            let b = other.as_limbs();
+            let mut acc = 0;
+            const_range_for!(i in 0..LIMBS => {
+                acc |= a[i] ^ b[i];
+            });
+            acc == 0
         } else {
             let a = self.as_limbs();
             let b = other.as_limbs();


### PR DESCRIPTION
## Summary

Reformulates `const_eq`'s ≤16-limb path from u128 double-word chunks to a limb-wise XOR/OR fold, fixing a large dependent-use latency penalty on x86-64 while keeping the aarch64 codegen from #615 bit-identical. Measured on Zen 2 (Threadripper 3990X): **−44% per-link latency for `const_eq` at 256 bits** (3.71 → 2.09 ns), −52% at 512 bits, with all distribution and throughput guards flat. On Apple M-series the same change is −18.5% at 256 bits.

Stacks on #615 (its two commits are included here) and on the real-world benchmark suite this investigation used; draft until both land or this gets rebased onto them.

## The problem

The `chained/*` latency benches (64 serially-dependent op applications, so the CPU cannot overlap iterations) showed that *consuming* an equality result costs far more than producing one on Zen 2:

| bench (Zen 2) | standalone | chained, per link |
|---|---|---|
| `eq/256` (derived `==`) | 1.30 ns | **8.45 ns** |
| `const_eq/256` (#615 dw form) | 0.85 ns | **3.71 ns** |

Root cause, from the generated asm: both forms lower to an SSE sequence (`movdqu`×4, `pxor`×2, `por`, `ptest`, `sete`). In a dependency chain the consumer updates the limbs with scalar code (4×8-byte stores from an `adc` chain), and the next compare reloads them as 16-byte vector loads. A 16-byte load spanning two 8-byte stores **fails store-to-load forwarding** and stalls until the stores drain — that, plus the `ptest → sete` vector→scalar domain crossing, is the 8.45 ns/link. This is the x86-64 sibling of the aarch64 NEON/`fmov` pathology #615 fixed, but worse (6.5× vs 4×).

## The fix

```rust
// LIMBS <= EQ_FOLD_MAX_LIMBS (16):
let mut acc = 0;
const_range_for!(i in 0..LIMBS => {
    acc |= a[i] ^ b[i];
});
acc == 0
```

No `cfg(target_arch)` needed — LLVM canonicalizes the `&`-chain of limb equalities, the u128 double-word chain, and this fold to *identical* IR on aarch64 (all lower to the same `ccmp` flag chain #615 chose, verified by symbol-aliased asm), but on x86-64 only the u64 fold escapes re-vectorization when the result feeds a dependency chain:

| context | dw chunks (#615) | limb-wise fold (this PR) |
|---|---|---|
| x86-64, dependent use | `pxor`/`ptest` + STLF stall | **pure-GPR `xor`/`or`, no memory round-trip** |
| x86-64, standalone | `pxor`/`ptest` | `ptest` at 8+ limbs; scalar at 4 limbs |
| aarch64, dependent use | `ccmp` flag chain | `ccmp` flag chain (identical) |
| aarch64, standalone | `ccmp` | NEON `cmeq`/`umaxv` |

`is_zero`/`const_is_zero` inherit the fix through the existing `const_eq(&ZERO)` routing; the `> 16` limb paths (counting loop, OR-fold, `bcmp` against `ZERO`) are untouched.

## Measurements

Criterion, `chained/*` reported per link (reported time ÷ 64). Zen 2 = Threadripper 3990X pinned with `taskset`; M-series = Apple Silicon.

**Latency (the target):**

| bench | Zen 2 before → after | M-series before → after |
|---|---|---|
| `chained/const_eq/256` | 3.71 → **2.09 ns (−44%)** | 2.26 → **1.83 ns (−18.5%)** |
| `chained/const_eq/512` | ~6.5 (unstable) → **3.40 ns (−52%)** | 3.33 → 2.96 ns (−11%) |
| `chained/is_zero/256` | 1.75 → 1.72 ns (−3.5%) | 1.87 → 1.88 ns (flat) |
| `chained/const_is_zero/256` | 1.73 → 1.72 ns | 1.83 → 1.89 ns |
| `is_zero/384`, `/512` standalone | **−18% … −23%** | −3.5% |

**Guards (must not move, and didn't):**

| bench | Zen 2 | M-series |
|---|---|---|
| `dist/eq/{equal,differ_low,differ_high,mixed50}/256` | −2% | flat |
| `dist/is_zero/mixed10/256` | flat | flat |
| `chained/eq/*` (derived `==`, untouched) | +2% (noise) | flat |
| `eq`/`is_zero`/`const_*` at 64–192, 4096 bits | noise band (±7%) | noise band |

**Known tradeoff:** standalone `const_eq/256` throughput on Zen 2 goes 0.85 → 1.12 ns (+34%; `dist/const_eq/*` show the same, flat across distributions since both forms are branchless). At exactly 4 limbs x86-64 keeps even the standalone fold scalar; at 8+ limbs it re-vectorizes (`const_eq/512` standalone is unchanged). 1.12 ns still beats the derived `==` (1.32 ns) on the same inputs, and an equality result in real code is almost always consumed dependently — which is where the 44% win is — so this looks like the right trade. Documented in the `EQ_FOLD_MAX_LIMBS` comment.

## What this can't fix

`chained/eq/256` — the derived `==` itself — stays at ~8.5 ns/link on Zen 2. `#[derive(PartialEq)]` must remain (removing it breaks `StructuralPartialEq`, i.e. `Uint` constants in `match` patterns), so its `bcmp`-shaped lowering is not ours to change. Incidentally, the benches show how fragile that lowering is: the untouched `eq/192` flipped from 1.5 ns (inlined) to 7.8 ns (out-of-line `bcmp` call) purely from unrelated code motion in the bench binary, and `eq/384`/`eq/512` already sit at ~10.5 ns standalone on Linux/Zen 2. Latency-sensitive code should prefer `const_eq`/`is_zero`.

## Commits

- 7 × `bench:` — the real-world benchmark suite (fields/chained/curves/dist groups) this investigation was run with
- 2 × `perf: …` (cherry-picks of #615)
- `bench: add const_eq/const_is_zero chained + dist variants, 512-bit widths` — new guards used above
- `perf: reformulate const_eq fold to stay scalar under dependent use` — the fix

## Testing

- `cargo test --lib`: 147 passed (includes `test_const_eq_ctfe` compile-time evaluation, proptest equivalence of `const_eq`/`const_is_zero` vs `==`/`is_zero` across all `SIZES`, and single-limb-difference detection)
- `cargo clippy --all-targets`: clean; `cargo +nightly fmt --check`: clean
- Asm inspected on both targets (x86-64 generic and aarch64) for standalone and chained contexts at 4, 8, and 16 limbs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
