### PR TITLE
chore: infer rustfmt edition

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,4 @@
 # See: https://github.com/rust-lang/rustfmt/blob/master/Configurations.md
-edition = "2021"
 # group_imports = "One"
 imports_granularity = "Crate"
 use_field_init_shorthand = true


### PR DESCRIPTION
Removes the redundant Rust 2021 override from `rustfmt.toml` so `cargo fmt` infers the workspace's Rust 2024 edition. Reformatting produces no Rust source changes.