### PR TITLE
chore: release 1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.0] - 2026-07-30
+
 ### Changed
 
+- Open-code `PartialEq` and `is_zero` on riscv to avoid `memcmp` libcalls ([#604])
 - Run the core test suite on `wasm32-wasip1` in CI to catch 32-bit pointer-width bugs ([#609])
 - Make `reverse_bits`, `most_significant_bits`, `inv_ring`, `checked_pow`, `strict_pow`, `overflowing_pow`, `pow`, `saturating_pow`, `wrapping_pow`, `from_limbs_slice`, `checked_from_limbs_slice`, `wrapping_from_limbs_slice`, `overflowing_from_limbs_slice`, `saturating_from_limbs_slice`, `from_uint`, and `checked_from_uint` `const` ([#614])
 
@@ -26,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mark `addmul_nx1`/`submul_nx1` `unsafe` and close soundness / safety-contract gaps in the unstable `algorithms` module ([#612])
 
 [#603]: https://github.com/alloy-rs/ruint/pull/603
+[#604]: https://github.com/alloy-rs/ruint/pull/604
 [#605]: https://github.com/alloy-rs/ruint/pull/605
 [#606]: https://github.com/alloy-rs/ruint/pull/606
 [#607]: https://github.com/alloy-rs/ruint/pull/607
@@ -562,7 +566,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- links to version -->
 
-[unreleased]: https://github.com/alloy-rs/ruint/compare/v1.18.0...HEAD
+[unreleased]: https://github.com/alloy-rs/ruint/compare/v1.20.0...HEAD
+[1.20.0]: https://github.com/alloy-rs/ruint/releases/tag/v1.20.0
+[1.19.0]: https://github.com/alloy-rs/ruint/releases/tag/v1.19.0
 [1.18.0]: https://github.com/alloy-rs/ruint/releases/tag/v1.18.0
 [1.17.2]: https://github.com/alloy-rs/ruint/releases/tag/v1.17.2
 [1.17.1]: https://github.com/alloy-rs/ruint/releases/tag/v1.17.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruint"
 description = "Unsigned integer type with const-generic bit length"
-version = "1.19.0"
+version = "1.20.0"
 keywords = ["uint"]
 categories = ["mathematics"]
 include = [".cargo/", "src/", "README.md"]


### PR DESCRIPTION
Bumps the crate version to `1.20.0` and updates the changelog for all changes since `v1.19.0`.

Minor bump: #614 const-ifies a batch of `Uint` methods — an additive API-surface change, consistent with how prior const-ification releases were versioned (1.15.0, 1.19.0). No breaking changes.

Also in this PR:
- Adds the missing changelog entry for #604 (riscv `PartialEq`/`is_zero` open-coding)
- Fixes the stale `[unreleased]` compare link and adds the missing `[1.19.0]`/`[1.20.0]` release links (the 1.19.0 release PR missed the link-footer update)

### Changed
- Open-code `PartialEq` and `is_zero` on riscv to avoid `memcmp` libcalls (#604)
- Run the core test suite on `wasm32-wasip1` in CI (#609)
- Make `reverse_bits`, `most_significant_bits`, `inv_ring`, the `pow` family, the `from_limbs_slice` family, `from_uint`, and `checked_from_uint` `const` (#614)

### Fixed
- Fix `overflowing_shl`/`overflowing_shr` overflow-flag false negatives, which also corrected the dependent `checked_*`/`strict_*`/`saturating_*` shifts and `byte()` (#603)
- Fix `from_str_radix` rejecting the lowercase digits `g`–`z` in radix 64 (#605)
- Reject non-finite `f64` in `TryFrom<f64>` and saturate `Uint`→`f64` conversions at 2^1024 for large `BITS` (#606)
- `try_from_be_slice`/`try_from_le_slice` now return `None` instead of panicking for `BITS % 64` in `57..=63` (#607)
- `from_str_radix` and `to_base_be` no longer hang or silently accept radix/base 0 or 1 (#608)
- `checked_log`, `checked_log2`, and `checked_log10` no longer panic for small bit-widths where the base constant does not fit the type (#610)
- Fix incorrect doc comments and formulas in the `add`, `mul`, and `gcd` algorithms (#611)
- Mark `addmul_nx1`/`submul_nx1` `unsafe` and close soundness / safety-contract gaps in the unstable `algorithms` module (#612)

🤖 Generated with [Claude Code](https://claude.com/claude-code)